### PR TITLE
Patched gcore extension v1.6.1.

### DIFF
--- a/extensions/gcore.c
+++ b/extensions/gcore.c
@@ -1,0 +1,554 @@
+/* gcore.c -- core analysis suite
+ *
+ * Copyright (C) 2010, 2011 FUJITSU LIMITED
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "defs.h"
+#include <gcore_defs.h>
+#include <stdint.h>
+#include <elf.h>
+
+static void gcore_offset_table_init(void);
+static void gcore_size_table_init(void);
+static void gcore_machdep_init(void);
+
+static void do_gcore(char *arg);
+static void print_version(void);
+
+static struct command_table_entry command_table[] = {
+	{ "gcore", cmd_gcore, help_gcore, 0 },
+	{ (char *)NULL }                               
+};
+
+int 
+_init(void) /* Register the command set. */
+{
+	gcore_offset_table_init();
+	gcore_size_table_init();
+	gcore_coredump_table_init();
+	gcore_arch_table_init();
+	gcore_arch_regsets_init();
+	gcore_machdep_init();
+        register_extension(command_table);
+	return 1;
+}
+ 
+int 
+_fini(void) 
+{ 
+	return 1;
+}
+
+char *help_gcore[] = {
+"gcore",
+"gcore - retrieve a process image as a core dump",
+"\n"
+"  gcore [-v vlevel] [-f filter] [pid | taskp]*\n"
+"  This command retrieves a process image as a core dump.",
+"  ",
+"    -v Display verbose information according to vlevel:",
+"  ",
+"           progress  library error  page fault",
+"       ---------------------------------------",
+"         0",
+"         1    x",
+"         2                  x",
+"         4                                x    (default)",
+"         7    x             x             x",
+"  ",
+"    -f Specify kinds of memory to be written into core dumps according to",
+"       the filter flag in bitwise:",
+"  ",
+"           AP  AS  FP  FS  ELF HP  HS  DD",
+"       ----------------------------------",
+"         0",
+"         1  x",
+"         2      x",
+"         4          x",
+"         8              x",
+"        16          x       x",
+"        32                      x",
+"        64                          x",
+"       128                              x",
+"       255  x   x   x   x   x   x   x   x",
+" ",
+"        AP  Anonymous Private Memory",
+"        AS  Anonymous Shared Memory",
+"        FP  File-Backed Private Memory",
+"        FS  File-Backed Shared Memory",
+"        ELF ELF header pages in file-backed private memory areas",
+"        HP  Hugetlb Private Memory",
+"        HS  Hugetlb Shared Memory",
+"        DD  Memory advised using madvise with MADV_DONTDUMP flag",
+" ",
+"    -V Display version information",
+"  ",
+"  If no pid or taskp is specified, gcore tries to retrieve the process image",
+"  of the current task context.",
+"  ",
+"  The file name of a generated core dump is core.<pid> where pid is PID of",
+"  the specified process.",
+"  ",
+"  For a multi-thread process, gcore generates a core dump containing",
+"  information for all threads, which is similar to a behaviour of the ELF",
+"  core dumper in Linux kernel.",
+"  ",
+"  Notice the difference of PID on between crash and linux that ps command in",
+"  crash utility displays LWP, while ps command in Linux thread group tid,",
+"  precisely PID of the thread group leader.",
+"  ",
+"  gcore provides core dump filtering facility to allow users to select what",
+"  kinds of memory maps to be included in the resulting core dump. There are",
+"  7 kinds memory maps in total, and you can set it up with set command.",
+"  For more detailed information, please see a help command message.",
+"  ",
+"EXAMPLES",
+"  Specify the process you want to retrieve as a core dump. Here assume the",
+"  process with PID 12345.",
+"  ",
+"    crash> gcore 12345",
+"    Saved core.12345",
+"    crash>",
+"  ",
+"  Next, specify by TASK. Here assume the process placing at the address",
+"  f9d7000 with PID 32323.",
+"  ",
+"    crash> gcore f9d78000",
+"    Saved core.32323",
+"    crash>",
+"  ",
+"  If multiple arguments are given, gcore performs dumping process in the",
+"  order the arguments are given.",
+"  ",
+"    crash> gcore 5217 ffff880136d72040 23299 24459 ffff880136420040",
+"    Saved core.5217",
+"    Saved core.1130",
+"    Saved core.1130",
+"    Saved core.24459",
+"    Saved core.30102",
+"    crash>",
+"  ",
+"  If no argument is given, gcore tries to retrieve the process of the current",
+"  task context.",
+"  ",
+"    crash> set",
+"         PID: 54321",
+"     COMMAND: \"bash\"",
+"        TASK: e0000040f80c0000",
+"         CPU: 0",
+"       STATE: TASK_INTERRUPTIBLE",
+"    crash> gcore",
+"    Saved core.54321",
+"  ",
+"  When a multi-thread process is specified, the generated core file name has",
+"  the thread leader's PID; here it is assumed to be 12340.",
+"  ",
+"    crash> gcore 12345",
+"    Saved core.12340",
+"  ",
+"  It is not allowed to specify two same options at the same time.",
+"  ",
+"    crash> gcore -v 1 1234 -v 1",
+"    Usage: gcore",
+"      gcore [-v vlevel] [-f filter] [pid | taskp]*",
+"      gcore -d",
+"    Enter \"help gcore\" for details.",
+"  ",
+"  It is allowed to specify -v and -f options in a different order.",
+"  ",
+"    crash> gcore -v 2 5201 -f 21 ffff880126ff9520 5205",
+"    Saved core.5174",
+"    Saved core.5217",
+"    Saved core.5167",
+"    crash> gcore 5201 ffff880126ff9520 -f 21 5205 -v 2",
+"    Saved core.5174",
+"    Saved core.5217",
+"    Saved core.5167",
+"  ",
+NULL,
+};
+
+void
+cmd_gcore(void)
+{
+	char *foptarg, *voptarg;
+	int c, optversion;
+
+	if (ACTIVE())
+		error(FATAL, "no support on live kernel\n");
+
+	gcore_dumpfilter_set_default();
+	gcore_verbose_set_default();
+
+	foptarg = voptarg = NULL;
+	optversion = FALSE;
+
+	while ((c = getopt(argcnt, args, "f:v:V")) != EOF) {
+		switch (c) {
+		case 'V':
+			optversion = TRUE;
+			break;
+		case 'f':
+			if (foptarg)
+				goto argerr;
+			foptarg = optarg;
+			break;
+		case 'v':
+			if (voptarg)
+				goto argerr;
+			voptarg = optarg;
+			break;
+		default:
+		argerr:
+			argerrs++;
+			break;
+		}
+	}
+
+	if (argerrs) {
+		cmd_usage(pc->curcmd, SYNOPSIS);
+	}
+
+	if (optversion) {
+		print_version();
+		return;
+	}
+
+	if (foptarg) {
+		ulong value;
+
+		if (!decimal(foptarg, 0))
+			error(FATAL, "filter must be a decimal: %s.\n",
+			      foptarg);
+
+		value = stol(foptarg, gcore_verbose_error_handle(), NULL);
+		if (!gcore_dumpfilter_set(value))
+			error(FATAL, "invalid filter value: %s.\n", foptarg);
+	}
+
+	if (voptarg) {
+		ulong value;
+
+		if (!decimal(voptarg, 0))
+			error(FATAL, "vlevel must be a decimal: %s.\n",
+			      voptarg);
+
+		value = stol(voptarg, gcore_verbose_error_handle(), NULL);
+		if (!gcore_verbose_set(value))
+			error(FATAL, "invalid vlevel: %s.\n", voptarg);
+
+	}
+
+	if (!args[optind]) {
+		do_gcore(NULL);
+		return;
+	}
+
+	for (; args[optind]; optind++) {
+		do_gcore(args[optind]);
+		free_all_bufs();
+	}
+
+}
+
+/**
+ * do_gcore - do process core dump for a given task
+ *
+ * @arg string that refers to PID or task context's address
+ *
+ * Given the string, arg, refering to PID or task context's address,
+ * do_gcore tries to do process coredump for the corresponding
+ * task. If the string given is NULL, do_gcore does the process dump
+ * for the current task context.
+ *
+ * Here is the unique exception point in gcore sub-command. Any fatal
+ * action during gcore sub-command will come back here. Look carefully
+ * at how IN_FOREACH is used here.
+ *
+ * Dynamic allocation in gcore sub-command fully depends on buffer
+ * mechanism provided by crash utility. do_gcore() never makes freeing
+ * operation. Thus, it is necessary to call free_all_bufs() each time
+ * calling do_gcore(). See the end of cmd_gcore().
+ */
+static void do_gcore(char *arg)
+{
+	if (!setjmp(pc->foreach_loop_env)) {
+		struct task_context *tc;
+		ulong dummy;
+
+		BZERO(gcore, sizeof(struct gcore_one_session_data));
+
+		pc->flags |= IN_FOREACH;
+
+		if (arg) {
+			if (!IS_A_NUMBER(arg))
+				error(FATAL, "neither pid nor taskp: %s\n",
+				      args[optind]);
+
+			if (STR_INVALID == str_to_context(arg, &dummy, &tc))
+				error(FATAL, "invalid task or pid: %s\n",
+				      args[optind]);
+		} else
+			tc = CURRENT_CONTEXT();
+
+		if (is_kernel_thread(tc->task))
+			error(FATAL, "The specified task is a kernel thread.\n");
+
+		if (tc != CURRENT_CONTEXT()) {
+			gcore->orig_task = CURRENT_TASK();
+			(void) set_context(tc->task, NO_PID);
+		}
+
+		snprintf(gcore->corename, CORENAME_MAX_SIZE + 1, "core.%lu.%s",
+			 task_tgid(CURRENT_TASK()), CURRENT_COMM());
+
+		gcore_elf_init(gcore);
+
+		gcore_coredump();
+	}
+
+	pc->flags &= ~IN_FOREACH;
+
+	if (gcore->fp != NULL) {
+		if (fflush(gcore->fp) == EOF) {
+			error(FATAL, "%s: flush %s\n", gcore->corename,
+			      strerror(errno));
+		}
+		if (fclose(gcore->fp) == EOF) {
+			gcore->fp = NULL;
+			error(FATAL, "%s: close %s\n", gcore->corename,
+			      strerror(errno));
+		}
+		gcore->fp = NULL;
+	}
+
+	if (gcore->flags & GCF_UNDER_COREDUMP) {
+		if (gcore->flags & GCF_SUCCESS)
+			fprintf(fp, "Saved %s\n", gcore->corename);
+		else
+			fprintf(fp, "Failed.\n");
+	}
+
+	if (gcore->orig_task)
+		(void)set_context(gcore->orig_task, NO_PID);
+
+}
+
+static void print_version(void)
+{
+	fprintf(fp, "crash gcore command: version " VERSION " (released on "
+		RELEASE_DATE ")\n");
+	fprintf(fp, "Copyright (C) " PERIOD "  Fujitsu Limited\n");
+}
+
+static void gcore_offset_table_init(void)
+{
+	GCORE_MEMBER_OFFSET_INIT(cpuinfo_x86_x86_capability, "cpuinfo_x86", "x86_capability");
+	GCORE_MEMBER_OFFSET_INIT(cred_gid, "cred", "gid");
+	GCORE_MEMBER_OFFSET_INIT(cred_uid, "cred", "uid");
+	GCORE_MEMBER_OFFSET_INIT(desc_struct_base0, "desc_struct", "base0");
+	GCORE_MEMBER_OFFSET_INIT(desc_struct_base1, "desc_struct", "base1");
+	GCORE_MEMBER_OFFSET_INIT(desc_struct_base2, "desc_struct", "base2");
+	GCORE_MEMBER_OFFSET_INIT(fpu_state, "fpu", "state");
+	GCORE_MEMBER_OFFSET_INIT(inode_i_nlink, "inode", "i_nlink");
+	if (GCORE_INVALID_MEMBER(inode_i_nlink))
+		GCORE_ANON_MEMBER_OFFSET_INIT(inode_i_nlink, "inode", "i_nlink");
+	GCORE_MEMBER_OFFSET_INIT(nsproxy_pid_ns, "nsproxy", "pid_ns");
+	if (GCORE_INVALID_MEMBER(nsproxy_pid_ns))
+		GCORE_MEMBER_OFFSET_INIT(nsproxy_pid_ns, "nsproxy", "pid_ns_for_children");
+	GCORE_MEMBER_OFFSET_INIT(mm_context_t_vdso, "mm_context_t", "vdso");
+	GCORE_MEMBER_OFFSET_INIT(mm_struct_arg_start, "mm_struct", "arg_start");
+	GCORE_MEMBER_OFFSET_INIT(mm_struct_arg_end, "mm_struct", "arg_end");
+	GCORE_MEMBER_OFFSET_INIT(mm_struct_map_count, "mm_struct", "map_count");
+	GCORE_MEMBER_OFFSET_INIT(mm_struct_reserved_vm, "mm_struct", "reserved_vm");
+	GCORE_MEMBER_OFFSET_INIT(mm_struct_saved_auxv, "mm_struct", "saved_auxv");
+	GCORE_MEMBER_OFFSET_INIT(mm_struct_saved_files, "mm_struct", "saved_files");
+	GCORE_MEMBER_OFFSET_INIT(mm_struct_context, "mm_struct", "context");
+	GCORE_MEMBER_OFFSET_INIT(pid_level, "pid", "level");
+	GCORE_MEMBER_OFFSET_INIT(pid_namespace_level, "pid_namespace", "level");
+        if (MEMBER_EXISTS("pt_regs", "ax"))
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_ax, "pt_regs", "ax");
+        else
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_ax, "pt_regs", "eax");
+        if (MEMBER_EXISTS("pt_regs", "bp"))
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_bp, "pt_regs", "bp");
+        else
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_bp, "pt_regs", "ebp");
+        if (MEMBER_EXISTS("pt_regs", "bx"))
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_bx, "pt_regs", "bx");
+        else
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_bx, "pt_regs", "ebx");
+        if (MEMBER_EXISTS("pt_regs", "cs"))
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_cs, "pt_regs", "cs");
+        else
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_cs, "pt_regs", "xcs");
+        if (MEMBER_EXISTS("pt_regs", "cx"))
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_cx, "pt_regs", "cx");
+        else
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_cx, "pt_regs", "ecx");
+        if (MEMBER_EXISTS("pt_regs", "di"))
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_di, "pt_regs", "di");
+        else
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_di, "pt_regs", "edi");
+        if (MEMBER_EXISTS("pt_regs", "ds"))
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_ds, "pt_regs", "ds");
+        else
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_ds, "pt_regs", "xds");
+        if (MEMBER_EXISTS("pt_regs", "dx"))
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_dx, "pt_regs", "dx");
+        else
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_dx, "pt_regs", "edx");
+        if (MEMBER_EXISTS("pt_regs", "es"))
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_es, "pt_regs", "es");
+        else
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_es, "pt_regs", "xes");
+        if (MEMBER_EXISTS("pt_regs", "flags"))
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_flags, "pt_regs", "flags");
+        else
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_flags, "pt_regs", "eflags");
+	GCORE_MEMBER_OFFSET_INIT(pt_regs_fs, "pt_regs", "fs");
+	GCORE_MEMBER_OFFSET_INIT(pt_regs_gs, "pt_regs", "gs");
+        if (MEMBER_EXISTS("pt_regs", "ip"))
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_ip, "pt_regs", "ip");
+        else
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_ip, "pt_regs", "eip");
+        if (MEMBER_EXISTS("pt_regs", "orig_eax"))
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_orig_ax, "pt_regs", "orig_eax");
+        else
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_orig_ax, "pt_regs", "orig_ax");
+        if (MEMBER_EXISTS("pt_regs", "si"))
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_si, "pt_regs", "si");
+        else
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_si, "pt_regs", "esi");
+        if (MEMBER_EXISTS("pt_regs", "sp"))
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_sp, "pt_regs", "sp");
+        else
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_sp, "pt_regs", "esp");
+        if (MEMBER_EXISTS("pt_regs", "ss"))
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_ss, "pt_regs", "ss");
+        else
+	  GCORE_MEMBER_OFFSET_INIT(pt_regs_ss, "pt_regs", "xss");
+	GCORE_MEMBER_OFFSET_INIT(pt_regs_xfs, "pt_regs", "xfs");
+	GCORE_MEMBER_OFFSET_INIT(pt_regs_xgs, "pt_regs", "xgs");
+	GCORE_MEMBER_OFFSET_INIT(sched_entity_sum_exec_runtime, "sched_entity", "sum_exec_runtime");
+	GCORE_MEMBER_OFFSET_INIT(signal_struct_cutime, "signal_struct", "cutime");
+	GCORE_MEMBER_OFFSET_INIT(signal_struct_pgrp, "signal_struct", "pgrp");
+	GCORE_MEMBER_OFFSET_INIT(signal_struct_session, "signal_struct", "session");
+	GCORE_MEMBER_OFFSET_INIT(signal_struct_stime, "signal_struct", "stime");
+	GCORE_MEMBER_OFFSET_INIT(signal_struct_sum_sched_runtime, "signal_struct", "sum_sched_runtime");
+	GCORE_MEMBER_OFFSET_INIT(signal_struct_utime, "signal_struct", "utime");
+	GCORE_MEMBER_OFFSET_INIT(task_struct_cred, "task_struct", "cred");
+	GCORE_MEMBER_OFFSET_INIT(task_struct_gid, "task_struct", "gid");
+	GCORE_MEMBER_OFFSET_INIT(task_struct_group_leader, "task_struct", "group_leader");
+	GCORE_MEMBER_OFFSET_INIT(task_struct_real_cred, "task_struct", "real_cred");
+	if (MEMBER_EXISTS("task_struct", "real_parent"))
+		GCORE_MEMBER_OFFSET_INIT(task_struct_real_parent, "task_struct", "real_parent");
+	else if (MEMBER_EXISTS("task_struct", "parent"))
+		GCORE_MEMBER_OFFSET_INIT(task_struct_real_parent, "task_struct", "parent");
+	GCORE_MEMBER_OFFSET_INIT(task_struct_se, "task_struct", "se");
+	GCORE_MEMBER_OFFSET_INIT(task_struct_static_prio, "task_struct", "static_prio");
+	GCORE_MEMBER_OFFSET_INIT(task_struct_uid, "task_struct", "uid");
+	GCORE_MEMBER_OFFSET_INIT(task_struct_used_math, "task_struct", "used_math");
+	GCORE_MEMBER_OFFSET_INIT(thread_info_status, "thread_info", "status");
+	GCORE_MEMBER_OFFSET_INIT(thread_info_fpstate, "thread_info", "fpstate");
+	GCORE_MEMBER_OFFSET_INIT(thread_info_vfpstate, "thread_info", "vfpstate");
+	GCORE_MEMBER_OFFSET_INIT(thread_struct_ds, "thread_struct", "ds");
+	GCORE_MEMBER_OFFSET_INIT(thread_struct_es, "thread_struct", "es");
+	if (MEMBER_EXISTS("thread_struct", "fs"))
+		GCORE_MEMBER_OFFSET_INIT(thread_struct_fs, "thread_struct", "fs");
+	else
+		GCORE_MEMBER_OFFSET_INIT(thread_struct_fs, "thread_struct", "fsbase");
+	GCORE_MEMBER_OFFSET_INIT(thread_struct_fsindex, "thread_struct", "fsindex");
+	GCORE_MEMBER_OFFSET_INIT(thread_struct_fpu, "thread_struct", "fpu");
+	if (MEMBER_EXISTS("thread_struct", "gs"))
+		GCORE_MEMBER_OFFSET_INIT(thread_struct_gs, "thread_struct", "gs");
+	else
+		GCORE_MEMBER_OFFSET_INIT(thread_struct_gs, "thread_struct", "gsbase");
+	GCORE_MEMBER_OFFSET_INIT(thread_struct_gsindex, "thread_struct", "gsindex");
+	GCORE_MEMBER_OFFSET_INIT(thread_struct_i387, "thread_struct", "i387");
+	GCORE_MEMBER_OFFSET_INIT(thread_struct_tls_array, "thread_struct", "tls_array");
+	if (MEMBER_EXISTS("thread_struct", "usersp"))
+		GCORE_MEMBER_OFFSET_INIT(thread_struct_usersp, "thread_struct", "usersp");
+	else if (MEMBER_EXISTS("thread_struct", "userrsp"))
+		GCORE_MEMBER_OFFSET_INIT(thread_struct_usersp, "thread_struct", "userrsp");
+	GCORE_MEMBER_OFFSET_INIT(thread_struct_sp0, "thread_struct", "sp0");
+	if (MEMBER_EXISTS("thread_struct", "xstate"))
+		GCORE_MEMBER_OFFSET_INIT(thread_struct_xstate, "thread_struct", "xstate");
+	else if (MEMBER_EXISTS("thread_struct", "i387"))
+		GCORE_MEMBER_OFFSET_INIT(thread_struct_xstate, "thread_struct", "i387");
+	GCORE_MEMBER_OFFSET_INIT(thread_struct_io_bitmap_max, "thread_struct", "io_bitmap_max");
+	GCORE_MEMBER_OFFSET_INIT(thread_struct_io_bitmap_ptr, "thread_struct", "io_bitmap_ptr");
+	if (GCORE_INVALID_MEMBER(thread_struct_io_bitmap_max)) {
+		GCORE_MEMBER_OFFSET_INIT(thread_struct_io_bitmap_max, "io_bitmap", "max");
+		GCORE_MEMBER_OFFSET_INIT(thread_struct_io_bitmap_ptr, "io_bitmap", "bitmap");
+	}
+	GCORE_MEMBER_OFFSET_INIT(user_regset_n, "user_regset", "n");
+	GCORE_MEMBER_OFFSET_INIT(vm_area_struct_anon_vma, "vm_area_struct", "anon_vma");
+	GCORE_MEMBER_OFFSET_INIT(vm_area_struct_vm_ops, "vm_area_struct", "vm_ops");
+	GCORE_MEMBER_OFFSET_INIT(vm_area_struct_vm_private_data, "vm_area_struct", "vm_private_data");
+	GCORE_MEMBER_OFFSET_INIT(vm_operations_struct_name, "vm_operations_struct", "name");
+	GCORE_MEMBER_OFFSET_INIT(vm_special_mapping_name, "vm_special_mapping", "name");
+
+	if (symbol_exists("_cpu_pda"))
+		GCORE_MEMBER_OFFSET_INIT(x8664_pda_oldrsp, "x8664_pda", "oldrsp");
+	GCORE_MEMBER_OFFSET_INIT(vfp_state_hard, "vfp_state", "hard");
+	GCORE_MEMBER_OFFSET_INIT(vfp_hard_struct_fpregs, "vfp_hard_struct", "fpregs");
+	GCORE_MEMBER_OFFSET_INIT(vfp_hard_struct_fpscr, "vfp_hard_struct", "fpscr");
+	GCORE_MEMBER_OFFSET_INIT(thread_struct_fpsimd_state, "thread_struct", "fpsimd_state");
+	GCORE_MEMBER_OFFSET_INIT(thread_struct_tp_value, "thread_struct", "tp_value");
+	if (GCORE_INVALID_MEMBER(thread_struct_fpsimd_state)) {
+		GCORE_ANON_MEMBER_OFFSET_INIT(thread_struct_fpsimd_state, "thread_struct", "uw.fpsimd_state");
+		GCORE_ANON_MEMBER_OFFSET_INIT(thread_struct_tp_value, "thread_struct", "uw.tp_value");
+	}
+	if (MEMBER_EXISTS("task_struct", "thread_pid"))
+		GCORE_MEMBER_OFFSET_INIT(task_struct_thread_pid, "task_struct", "thread_pid");
+	if (MEMBER_EXISTS("signal_struct", "pids"))
+		GCORE_MEMBER_OFFSET_INIT(signal_struct_pids, "signal_struct", "pids");
+}
+
+static void gcore_size_table_init(void)
+{
+	GCORE_STRUCT_SIZE_INIT(i387_union, "i387_union");
+	GCORE_STRUCT_SIZE_INIT(mm_context_t, "mm_context_t");
+	GCORE_MEMBER_SIZE_INIT(mm_struct_saved_auxv, "mm_struct", "saved_auxv");
+	GCORE_MEMBER_SIZE_INIT(mm_struct_saved_files, "mm_struct", "saved_files");
+	GCORE_MEMBER_SIZE_INIT(thread_struct_ds, "thread_struct", "ds");
+	GCORE_MEMBER_SIZE_INIT(thread_struct_es, "thread_struct", "es");
+	if (MEMBER_EXISTS("thread_struct", "fs"))
+		GCORE_MEMBER_SIZE_INIT(thread_struct_fs, "thread_struct", "fs");
+	else
+		GCORE_MEMBER_SIZE_INIT(thread_struct_fs, "thread_struct", "fsbase");
+	GCORE_MEMBER_SIZE_INIT(thread_struct_fsindex, "thread_struct", "fsindex");
+	if (MEMBER_EXISTS("thread_struct", "gs"))
+		GCORE_MEMBER_SIZE_INIT(thread_struct_gs, "thread_struct", "gs");
+	else
+		GCORE_MEMBER_SIZE_INIT(thread_struct_gs, "thread_struct", "gsbase");
+	GCORE_MEMBER_SIZE_INIT(thread_struct_gsindex, "thread_struct", "gsindex");
+	GCORE_MEMBER_SIZE_INIT(thread_struct_tls_array, "thread_struct", "tls_array");
+	GCORE_STRUCT_SIZE_INIT(thread_xstate, "thread_xstate");
+	GCORE_MEMBER_SIZE_INIT(vm_area_struct_anon_vma, "vm_area_struct", "anon_vma");
+	GCORE_MEMBER_SIZE_INIT(vfp_hard_struct_fpregs, "vfp_hard_struct", "fpregs");
+	GCORE_MEMBER_SIZE_INIT(vfp_hard_struct_fpscr, "vfp_hard_struct", "fpscr");
+
+}
+
+static void gcore_machdep_init(void)
+{
+	if (STRUCT_EXISTS("fault_data") || STRUCT_EXISTS("vm_fault"))
+		gcore_machdep->vm_alwaysdump = 0x04000000;
+	else
+		gcore_machdep->vm_alwaysdump = 0x08000000;
+
+	if (!gcore_arch_vsyscall_has_vm_alwaysdump_flag())
+		gcore_machdep->vm_alwaysdump = 0x00000000;
+}

--- a/extensions/gcore.mk
+++ b/extensions/gcore.mk
@@ -1,0 +1,123 @@
+#
+# Copyright (C) 2010 FUJITSU LIMITED
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+
+VERSION=1.6.1
+DATE=9 Dec 2020
+PERIOD=2010, 2011, 2012, 2013, 2014, 2016, 2017, 2018, 2019, 2020
+
+ARCH=UNSUPPORTED
+
+ifeq ($(shell arch), i686)
+  TARGET=X86
+  TARGET_CFLAGS=-D_FILE_OFFSET_BITS=64
+  ARCH=SUPPORTED
+endif
+
+ifeq ($(shell arch), x86_64)
+  TARGET=X86_64
+  TARGET_CFLAGS=
+  ARCH=SUPPORTED
+endif
+
+ifeq ($(shell arch), arm)
+  TARGET=ARM
+  TARGET_CFLAGS=
+  ARCH=SUPPORTED
+endif
+
+ifeq ($(shell arch), aarch64)
+  TARGET=ARM64
+  ARCH_CFLAGS=-D_SYS_UCONTEXT_H=1
+  ARCH=SUPPORTED
+endif
+
+ifeq ($(shell arch), mips)
+  TARGET=MIPS
+  TARGET_CFLAGS=
+  ARCH=SUPPORTED
+endif
+
+ifeq ($(shell arch), ppc64)
+  TARGET=PPC64
+  TARGET_CFLAGS=
+  ARCH=SUPPORTED
+endif
+
+ifeq ($(shell arch), ppc64le)
+  TARGET=PPC64
+  TARGET_CFLAGS=
+  ARCH=SUPPORTED
+endif
+
+ifeq ($(shell /bin/ls /usr/include/crash/defs.h 2>/dev/null), /usr/include/crash/defs.h)
+  INCDIR=/usr/include/crash
+endif
+ifeq ($(shell /bin/ls ./defs.h 2> /dev/null), ./defs.h)
+  INCDIR=.
+endif
+ifeq ($(shell /bin/ls ../defs.h 2> /dev/null), ../defs.h)
+  INCDIR=..
+endif
+
+GCORE_CFILES = \
+	libgcore/gcore_coredump.c \
+	libgcore/gcore_coredump_table.c \
+	libgcore/gcore_dumpfilter.c \
+	libgcore/gcore_elf_struct.c \
+	libgcore/gcore_global_data.c \
+	libgcore/gcore_regset.c \
+	libgcore/gcore_verbose.c
+
+ifneq (,$(findstring $(TARGET), X86 X86_64))
+GCORE_CFILES += libgcore/gcore_x86.c
+endif
+
+ifneq (,$(findstring $(TARGET), ARM))
+GCORE_CFILES += libgcore/gcore_arm.c
+endif
+
+ifneq (,$(findstring $(TARGET), ARM64))
+GCORE_CFILES += libgcore/gcore_arm64.c
+endif
+
+ifneq (,$(findstring $(TARGET), MIPS))
+GCORE_CFILES += libgcore/gcore_mips.c
+endif
+
+ifneq (,$(findstring $(TARGET), PPC64))
+GCORE_CFILES += libgcore/gcore_ppc64.c
+endif
+
+GCORE_OFILES = $(patsubst %.c,%.o,$(GCORE_CFILES))
+
+COMMON_CFLAGS=-Wall -I$(INCDIR) -I./libgcore -fPIC -D$(TARGET) \
+	-DVERSION='"$(VERSION)"' -DRELEASE_DATE='"$(DATE)"' \
+	-DPERIOD='"$(PERIOD)"'
+
+all: gcore.so
+
+gcore.so: gcore.c $(INCDIR)/defs.h
+	@if [ $(ARCH) = "UNSUPPORTED"  ]; then \
+		echo "gcore: architecture not supported"; \
+	else \
+		make -f gcore.mk $(GCORE_OFILES) && \
+		gcc $(RPM_OPT_FLAGS) $(CFLAGS) $(TARGET_CFLAGS) $(COMMON_CFLAGS) $(ARCH_CFLAGS) -nostartfiles -shared -rdynamic $(GCORE_OFILES) -o $@ $< ; \
+	fi;
+
+%.o: %.c $(INCDIR)/defs.h
+	gcc $(RPM_OPT_FLAGS) $(CFLAGS) $(TARGET_CFLAGS) $(COMMON_CFLAGS) $(ARCH_CFLAGS) -c -o $@ $<
+
+clean:
+	rm -f gcore.so
+	rm -f libgcore/gcore_*.o

--- a/extensions/libgcore/gcore_arm.c
+++ b/extensions/libgcore/gcore_arm.c
@@ -1,0 +1,157 @@
+/* gcore_arm.c -- core analysis suite
+ *
+ * Copyright (C) 2012 Marvell INC
+ * Author: Lei Wen <leiwen@marvell.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+#if defined(ARM)
+
+#include "defs.h"
+#include <gcore_defs.h>
+#include <stdint.h>
+#include <elf.h>
+#include <asm/ldt.h>
+
+static int gpr_get(struct task_context *target,
+		       const struct user_regset *regset,
+		       unsigned int size, void *buf)
+{
+	struct user_regs_struct *regs = (struct user_regs_struct *)buf;
+
+	BZERO(regs, sizeof(*regs));
+
+	readmem(machdep->get_stacktop(target->task) - 8 - SIZE(pt_regs), KVADDR,
+		regs, SIZE(pt_regs), "genregs_get: pt_regs",
+		gcore_verbose_error_handle());
+
+	return 0;
+}
+
+static int fpa_get(struct task_context *target,
+		       const struct user_regset *regset,
+		       unsigned int size, void *buf)
+{
+	struct user_fp *fp = (struct user_fp*)buf;
+
+	BZERO(fp, sizeof(*fp));
+	readmem(target->task + OFFSET(task_struct_thread_info)
+		+ GCORE_OFFSET(thread_info_fpstate),
+		KVADDR, fp, sizeof(*fp),
+		"fpa_get: fpstate",
+		gcore_verbose_error_handle());
+	return 0;
+}
+
+static int vfp_get(struct task_context *target,
+		       const struct user_regset *regset,
+		       unsigned int size, void *buf)
+{
+	struct user_vfp *vfp = (struct user_vfp*)buf;
+
+	BZERO(vfp, sizeof(*vfp));
+	readmem(target->task + OFFSET(task_struct_thread_info)
+		+ GCORE_OFFSET(thread_info_vfpstate)
+		+ GCORE_OFFSET(vfp_state_hard)
+		+ GCORE_OFFSET(vfp_hard_struct_fpregs),
+		KVADDR, &vfp->fpregs, GCORE_SIZE(vfp_hard_struct_fpregs),
+		"vfp_get: fpregs",
+		gcore_verbose_error_handle());
+
+	readmem(target->task + OFFSET(task_struct_thread_info)
+		+ GCORE_OFFSET(thread_info_vfpstate)
+		+ GCORE_OFFSET(vfp_state_hard)
+		+ GCORE_OFFSET(vfp_hard_struct_fpscr),
+		KVADDR, &vfp->fpscr, GCORE_SIZE(vfp_hard_struct_fpscr),
+		"vfp_get: fpregs",
+		gcore_verbose_error_handle());
+	return 0;
+}
+
+static inline int
+vfp_vector_active(struct task_context *target,
+		  const struct user_regset *regset)
+{
+	return !!symbol_exists("vfp_vector");
+}
+
+enum gcore_regset {
+	REGSET_GPR,
+	REGSET_FPR,
+	REGSET_VFP,
+};
+
+#define NT_ARM_VFP	0x400           /* ARM VFP/NEON registers */
+static struct user_regset arm_regsets[] = {
+	[REGSET_GPR] = {
+		.core_note_type = NT_PRSTATUS,
+		.name = "CORE",
+		.size = ELF_NGREG * sizeof(unsigned int),
+		.get = gpr_get,
+	},
+	[REGSET_FPR] = {
+		.core_note_type = NT_FPREGSET,
+		.name = "CORE",
+		.size = sizeof(struct user_fp),
+		.get = fpa_get,
+	},
+	[REGSET_VFP] = {
+		.core_note_type = NT_ARM_VFP,
+		.name = "CORE",
+		.size = ARM_VFPREGS_SIZE,
+		.active = vfp_vector_active,
+		.get = vfp_get,
+	},
+};
+#ifndef ARRAY_SIZE
+#  define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+#endif
+
+static const struct user_regset_view arm_regset_view = {
+	.name = "arm",
+	.regsets = arm_regsets,
+	.n = ARRAY_SIZE(arm_regsets),
+	.e_machine = EM_ARM,
+};
+
+const struct user_regset_view *
+task_user_regset_view(void)
+{
+	return &arm_regset_view;
+}
+
+int gcore_is_arch_32bit_emulation(struct task_context *tc)
+{
+	return FALSE;
+}
+
+/**
+ * Return an address to gate_vma.
+ */
+ulong gcore_arch_get_gate_vma(void)
+{
+	if (!symbol_exists("gate_vma"))
+		return 0UL;
+
+	return symbol_value("gate_vma");
+}
+
+char *gcore_arch_vma_name(ulong vma)
+{
+	return NULL;
+}
+
+int gcore_arch_vsyscall_has_vm_alwaysdump_flag(void)
+{
+	return FALSE;
+}
+
+#endif /* defined(ARM) */

--- a/extensions/libgcore/gcore_arm64.c
+++ b/extensions/libgcore/gcore_arm64.c
@@ -1,0 +1,252 @@
+/* gcore_arm64.c
+ *
+ * Copyright (C) 2014 Red Hat, Inc. All rights reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifdef ARM64
+
+#include "defs.h"
+#include <gcore_defs.h>
+#include <stdint.h>
+#include <elf.h>
+
+static int gpr_get(struct task_context *target,
+		   const struct user_regset *regset,
+		   unsigned int size, void *buf)
+{
+	struct user_pt_regs *regs = (struct user_pt_regs *)buf;
+
+	BZERO(regs, sizeof(*regs));
+
+	readmem(machdep->get_stacktop(target->task) -
+		machdep->machspec->user_eframe_offset - SIZE(pt_regs), KVADDR,
+		regs, sizeof(struct user_pt_regs), "gpr_get: user_pt_regs",
+		gcore_verbose_error_handle());
+
+	return 0;
+}
+
+static int fpr_get(struct task_context *target,
+		   const struct user_regset *regset,
+		   unsigned int size, void *buf)
+{
+	struct user_fpsimd_state *fpr = (struct user_fpsimd_state *)buf;
+
+	BZERO(fpr, sizeof(*fpr));
+	readmem(target->task + OFFSET(task_struct_thread)
+		+ GCORE_OFFSET(thread_struct_fpsimd_state),
+		KVADDR, fpr, sizeof(struct user_fpsimd_state),
+		"fpr_get: user_fpsimd_state",
+		gcore_verbose_error_handle());
+	return 0;
+}
+
+static int tls_get(struct task_context *target,
+		   const struct user_regset *regset,
+		   unsigned int size, void *buf)
+{
+	void *tls = (void *)buf;
+
+	BZERO(tls, size);
+	readmem(target->task + OFFSET(task_struct_thread)
+		+ GCORE_OFFSET(thread_struct_tp_value),
+		KVADDR, tls, sizeof(void *),
+		"tls_get: tp_value",
+		gcore_verbose_error_handle());
+	return 0;
+}
+
+enum gcore_regset {
+	REGSET_GPR,
+	REGSET_FPR,
+	REGSET_TLS,
+};
+
+static struct user_regset arm64_regsets[] = {
+	[REGSET_GPR] = {
+		.core_note_type = NT_PRSTATUS,
+		.name = "CORE",
+		.size = sizeof(struct elf_prstatus),
+		.get = gpr_get,
+	},
+	[REGSET_FPR] = {
+		.core_note_type = NT_FPREGSET,
+		.name = "CORE",
+		.size = sizeof(struct user_fpsimd_state),
+		.get = fpr_get,
+	},
+	[REGSET_TLS] = {
+		.core_note_type = NT_ARM_TLS,
+		.name = "CORE",
+		.size = sizeof(void *),
+		.get = tls_get,
+	},
+};
+#ifndef ARRAY_SIZE
+#  define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+#endif
+
+static const struct user_regset_view arm64_regset_view = {
+	.name = "arm64",
+	.regsets = arm64_regsets,
+	.n = ARRAY_SIZE(arm64_regsets),
+	.e_machine = EM_AARCH64,
+};
+
+#ifdef GCORE_ARCH_COMPAT
+enum compat_regset {
+	REGSET_COMPAT_GPR,
+	REGSET_COMPAT_VFP,
+};
+
+struct pt_regs {
+	struct user_pt_regs user_regs;
+	unsigned long orig_x0;
+	unsigned long syscallno;
+};
+
+static int compat_gpr_get(struct task_context *target,
+			  const struct user_regset *regset,
+			  unsigned int size, void *buf)
+{
+	struct pt_regs pt_regs;
+	struct user_regs_struct32 *regs = (struct user_regs_struct32 *)buf;
+
+	BZERO(&pt_regs, sizeof(pt_regs));
+	BZERO(regs, sizeof(*regs));
+
+	readmem(machdep->get_stacktop(target->task) -
+		machdep->machspec->user_eframe_offset - SIZE(pt_regs), KVADDR,
+		&pt_regs, sizeof(struct pt_regs), "compat_gpr_get: pt_regs",
+		gcore_verbose_error_handle());
+
+	regs->r0 = pt_regs.user_regs.regs[0];
+	regs->r1 = pt_regs.user_regs.regs[1];
+	regs->r2 = pt_regs.user_regs.regs[2];
+	regs->r3 = pt_regs.user_regs.regs[3];
+	regs->r4 = pt_regs.user_regs.regs[4];
+	regs->r5 = pt_regs.user_regs.regs[5];
+	regs->r6 = pt_regs.user_regs.regs[6];
+	regs->r7 = pt_regs.user_regs.regs[7];
+	regs->r8 = pt_regs.user_regs.regs[8];
+	regs->r9 = pt_regs.user_regs.regs[9];
+	regs->r10 = pt_regs.user_regs.regs[10];
+	regs->fp = pt_regs.user_regs.regs[11];
+	regs->ip = pt_regs.user_regs.regs[12];
+	regs->sp = pt_regs.user_regs.regs[13];
+	regs->lr = pt_regs.user_regs.regs[14];
+	regs->pc = pt_regs.user_regs.pc;
+	regs->cpsr = pt_regs.user_regs.pstate;
+	regs->ORIG_r0 = pt_regs.orig_x0;
+
+	return 0;
+}
+
+static int compat_vfp_get(struct task_context *target,
+			  const struct user_regset *regset,
+			  unsigned int size, void *buf)
+{
+	/*
+	 * The VFP registers are packed into the fpsimd_state, so they all sit
+	 * nicely together for us. We just need to create the fpscr separately.
+	 */
+	struct user_fpsimd_state *fpr = (struct user_fpsimd_state *)buf;
+	compat_ulong_t fpscr;
+
+	BZERO(fpr, sizeof(*fpr));
+	readmem(target->task + OFFSET(task_struct_thread)
+		+ GCORE_OFFSET(thread_struct_fpsimd_state),
+		KVADDR, fpr, sizeof(struct user_fpsimd_state),
+		"compat_fpr_get: user_fpsimd_state",
+		gcore_verbose_error_handle());
+
+	fpscr = (fpr->fpsr & VFP_FPSCR_STAT_MASK) |
+		(fpr->fpcr & VFP_FPSCR_CTRL_MASK);
+
+	fpr->fpcr = fpscr;
+
+	return 0;
+}
+
+#define NT_ARM_VFP	0x400           /* ARM VFP/NEON registers */
+static const struct user_regset aarch32_regsets[] = {
+	[REGSET_COMPAT_GPR] = {
+		.core_note_type = NT_PRSTATUS,
+		.name = "CORE",
+		.size = sizeof(struct user_regs_struct32),
+		.get = compat_gpr_get,
+	},
+	[REGSET_COMPAT_VFP] = {
+		.core_note_type = NT_ARM_VFP,
+		.name = "CORE",
+		.size = VFP_STATE_SIZE,
+		.get = compat_vfp_get,
+	},
+};
+
+static const struct user_regset_view aarch32_regset_view = {
+	.name = "aarch32",
+	.e_machine = EM_ARM,
+	.regsets = aarch32_regsets,
+	.n = ARRAY_SIZE(aarch32_regsets)
+};
+#endif /* GCORE_ARCH_COMPAT */
+
+const struct user_regset_view *
+task_user_regset_view(void)
+{
+#ifdef GCORE_ARCH_COMPAT
+	if (gcore_is_arch_32bit_emulation(CURRENT_CONTEXT()))
+		return &aarch32_regset_view;
+#endif /* GCORE_ARCH_COMPAT */
+	return &arm64_regset_view;
+}
+
+#ifdef GCORE_ARCH_COMPAT
+enum gcore_arm64_thread_info_flag
+{
+	TIF_32BIT = 22		/* 32bit process */
+};
+#endif /* GCORE_ARCH_COMPAT */
+
+int gcore_is_arch_32bit_emulation(struct task_context *tc)
+{
+#ifdef GCORE_ARCH_COMPAT
+	uint32_t flags;
+	char *thread_info_buf;
+
+	thread_info_buf = fill_thread_info(tc->thread_info);
+	flags = ULONG(thread_info_buf + OFFSET(thread_info_flags));
+
+	if (flags & (1UL << TIF_32BIT))
+		return TRUE;
+#endif /* GCORE_ARCH_COMPAT */
+	return FALSE;
+}
+
+ulong gcore_arch_get_gate_vma(void)
+{
+	return 0UL;
+}
+
+char *gcore_arch_vma_name(ulong vma)
+{
+	return NULL;
+}
+
+int gcore_arch_vsyscall_has_vm_alwaysdump_flag(void)
+{
+	return FALSE;
+}
+
+#endif

--- a/extensions/libgcore/gcore_compat_arm.h
+++ b/extensions/libgcore/gcore_compat_arm.h
@@ -1,0 +1,43 @@
+/* gcore_compat_arm.h -- core analysis suite
+ *
+ * Copyright (C) 2014 Marvell. Inc
+ * author: Wei Shu <weishu@marvell.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+#ifndef GCORE_COMPAT_ARM_H_
+#define GCORE_COMPAT_ARM_H_
+#include <stdint.h>
+
+typedef int32_t compat_time_t;
+typedef int32_t compat_pid_t;
+typedef uint32_t __compat_uid_t;
+typedef uint32_t __compat_gid_t;
+typedef int32_t compat_int_t;
+typedef uint32_t compat_ulong_t;
+
+struct compat_timeval {
+	compat_time_t	tv_sec;
+	int32_t	tv_usec;
+};
+
+typedef struct user_regs_struct32 compat_elf_gregset_t;
+
+/* Masks for extracting the FPSR and FPCR from the FPSCR */
+#define VFP_FPSCR_STAT_MASK	0xf800009f
+#define VFP_FPSCR_CTRL_MASK	0x07f79f00
+/*
+ * The VFP state has 32x64-bit registers and a single 32-bit
+ * control/status register.
+ */
+#define VFP_STATE_SIZE		((32 * 8) + 4)
+
+#endif /* GCORE_COMPAT_ARM_H_ */

--- a/extensions/libgcore/gcore_compat_x86.h
+++ b/extensions/libgcore/gcore_compat_x86.h
@@ -1,0 +1,37 @@
+/* gcore_compat_x86.h -- core analysis suite
+ *
+ * Copyright (C) 2011 FUJITSU LIMITED
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+#ifndef GCORE_COMPAT_X86_H_
+#define GCORE_COMPAT_X86_H_
+#include <stdint.h>
+
+typedef int32_t compat_time_t;
+typedef int32_t compat_pid_t;
+typedef uint16_t __compat_uid_t;
+typedef uint16_t __compat_gid_t;
+typedef int32_t compat_int_t;
+typedef uint32_t compat_ulong_t;
+
+struct compat_timeval {
+	compat_time_t	tv_sec;
+	int32_t	tv_usec;
+};
+
+#ifdef X86_64
+typedef struct user_regs_struct32 compat_elf_gregset_t;
+#else
+typedef struct user_regs_struct compat_elf_gregset_t;
+#endif
+
+#endif /* GCORE_COMPAT_X86_H_ */

--- a/extensions/libgcore/gcore_coredump.c
+++ b/extensions/libgcore/gcore_coredump.c
@@ -312,6 +312,7 @@ fill_psinfo_note(struct elf_note_info *info, struct task_context *tc,
         /* first copy the parameters from user space */
 	BZERO(psinfo, sizeof(struct elf_prpsinfo));
 
+	/*
 	mm_cache = fill_mm_struct(task_mm(tc->task, FALSE));
 
 	arg_start = ULONG(mm_cache + GCORE_OFFSET(mm_struct_arg_start));
@@ -330,6 +331,7 @@ fill_psinfo_note(struct elf_note_info *info, struct task_context *tc,
                 if (psinfo->pr_psargs[i] == 0)
                         psinfo->pr_psargs[i] = ' ';
         psinfo->pr_psargs[len] = 0;
+	*/
 
 	readmem(tc->task + GCORE_OFFSET(task_struct_real_parent), KVADDR,
 		&parent, sizeof(parent), "fill_psinfo: real_parent",
@@ -386,6 +388,7 @@ compat_fill_psinfo_note(struct elf_note_info *info,
         /* first copy the parameters from user space */
 	BZERO(psinfo, sizeof(struct elf_prpsinfo));
 
+	/*
 	mm_cache = fill_mm_struct(task_mm(tc->task, FALSE));
 
 	arg_start = ULONG(mm_cache + GCORE_OFFSET(mm_struct_arg_start));
@@ -404,6 +407,7 @@ compat_fill_psinfo_note(struct elf_note_info *info,
                 if (psinfo->pr_psargs[i] == 0)
                         psinfo->pr_psargs[i] = ' ';
         psinfo->pr_psargs[len] = 0;
+	*/
 
 	readmem(tc->task + GCORE_OFFSET(task_struct_real_parent), KVADDR,
 		&parent, sizeof(parent), "fill_psinfo: real_parent",

--- a/extensions/libgcore/gcore_coredump.c
+++ b/extensions/libgcore/gcore_coredump.c
@@ -1,0 +1,1182 @@
+/* gcore_coredump.c -- core analysis suite
+ *
+ * Copyright (C) 2010, 2011 FUJITSU LIMITED
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <defs.h>
+#include <gcore_defs.h>
+
+static struct elf_note_info *elf_note_info_init(void);
+
+static void fill_prstatus_note(struct elf_note_info *info,
+			       struct task_context *tc,
+			       struct memelfnote *memnote);
+static void fill_psinfo_note(struct elf_note_info *info,
+			     struct task_context *tc,
+			     struct memelfnote *memnote);
+static void fill_auxv_note(struct elf_note_info *info,
+			   struct task_context *tc,
+			   struct memelfnote *memnote);
+static int fill_files_note(struct elf_note_info *info,
+			   struct task_context *tc,
+			   struct memelfnote *memnote);
+
+#ifdef GCORE_ARCH_COMPAT
+static void compat_fill_prstatus_note(struct elf_note_info *info,
+				      struct task_context *tc,
+				      struct memelfnote *memnote);
+static void compat_fill_psinfo_note(struct elf_note_info *info,
+				    struct task_context *tc,
+				    struct memelfnote *memnote);
+static void compat_fill_auxv_note(struct elf_note_info *info,
+				  struct task_context *tc,
+				  struct memelfnote *memnote);
+static int compat_fill_files_note(struct elf_note_info *info,
+				  struct task_context *tc,
+				  struct memelfnote *memnote);
+#endif
+
+static void fill_elf_header(int phnum);
+static void fill_write_thread_core_info(FILE *fp, struct task_context *tc,
+					struct task_context *dump_tc,
+					struct elf_note_info *info,
+					const struct user_regset_view *view,
+					loff_t *offset, size_t *total);
+static int fill_write_note_info(FILE *fp, struct elf_note_info *info, int phnum,
+				loff_t *offset);
+static void fill_note(struct memelfnote *note, const char *name, int type,
+		      unsigned int sz, void *data);
+
+static int notesize(struct memelfnote *en);
+static void alignfile(FILE *fp, loff_t *foffset);
+static void writenote(struct memelfnote *men, FILE *fp, loff_t *foffset);
+static size_t get_note_info_size(struct elf_note_info *info);
+
+static inline int thread_group_leader(ulong task);
+
+static int uvtop_quiet(ulong vaddr, physaddr_t *paddr);
+
+void gcore_coredump(void)
+{
+	struct elf_note_info *info;
+	int map_count, phnum;
+	ulong vma, index, mmap;
+	loff_t offset;
+	char *mm_cache, *buffer = NULL;
+	ulong gate_vma;
+
+	gcore->flags |= GCF_UNDER_COREDUMP;
+
+	mm_cache = fill_mm_struct(task_mm(CURRENT_TASK(), TRUE));
+	if (!mm_cache)
+		error(FATAL, "The user memory space does not exist.\n");
+
+	mmap = ULONG(mm_cache + OFFSET(mm_struct_mmap));
+	map_count = INT(mm_cache + GCORE_OFFSET(mm_struct_map_count));
+
+	phnum = map_count;
+	phnum++; /* for note information */
+	gate_vma = gcore_arch_get_gate_vma();
+	if (gate_vma)
+		phnum++;
+
+	info = elf_note_info_init();
+
+	fill_elf_header(phnum);
+
+	progressf("Opening file %s ... \n", gcore->corename);
+	gcore->fp = fopen(gcore->corename, "w");
+	if (!gcore->fp)
+		error(FATAL, "%s: open: %s\n", gcore->corename,
+		      strerror(errno));
+	progressf("done.\n");
+
+	progressf("Writing ELF header ... \n");
+	if (!gcore->elf->ops->write_elf_header(gcore->elf, gcore->fp))
+		error(FATAL, "%s: write: %s\n", gcore->corename,
+		      strerror(errno));
+	progressf(" done.\n");
+
+	offset = gcore->elf->ops->calc_segment_offset(gcore->elf);
+
+	if (fseek(gcore->fp, offset, SEEK_SET) < 0) {
+		error(FATAL, "%s: fseek: %s\n", gcore->corename,
+		      strerror(errno));
+	}
+
+	progressf("Retrieving and writing note information ... \n");
+	fill_write_note_info(gcore->fp, info, phnum, &offset);
+	progressf("done.\n");
+
+	if (gcore->elf->ops->get_e_shoff(gcore->elf)) {
+		if (fseek(gcore->fp, gcore->elf->ops->get_e_shoff(gcore->elf),
+			  SEEK_SET) < 0) {
+			error(FATAL, "%s: fseek: %s\n", gcore->corename,
+			      strerror(errno));
+		}
+		progressf("Writing section header table ... \n");
+		if (!gcore->elf->ops->write_section_header(gcore->elf,
+							   gcore->fp))
+			error(FATAL, "%s: gcore: %s\n", gcore->corename,
+			      strerror(errno));
+		progressf("done.\n");
+	}
+
+	progressf("Writing PT_NOTE program header ... \n");
+	if (fseek(gcore->fp, gcore->elf->ops->get_e_phoff(gcore->elf),
+		  SEEK_SET) < 0) {
+		error(FATAL, "%s: fseek: %s\n", gcore->corename,
+		      strerror(errno));
+	}
+	offset = gcore->elf->ops->calc_segment_offset(gcore->elf);
+	gcore->elf->ops->fill_program_header(gcore->elf, PT_NOTE, 0, offset, 0,
+					     get_note_info_size(info), 0, 0);
+	if (!gcore->elf->ops->write_program_header(gcore->elf, gcore->fp))
+		error(FATAL, "%s: write: %s\n", gcore->corename,
+		      strerror(errno));
+	progressf("done.\n");
+
+	offset =
+		gcore->elf->ops->calc_segment_offset(gcore->elf)
+		+ get_note_info_size(info);
+	offset = roundup(offset, ELF_EXEC_PAGESIZE);
+
+	progressf("Writing PT_LOAD program headers ... \n");
+	FOR_EACH_VMA_OBJECT(vma, index, mmap, gate_vma) {
+		char *vma_cache;
+		ulong vm_start, vm_end, vm_flags;
+		uint64_t p_offset, p_filesz;
+		uint32_t p_flags;
+
+		vma_cache = fill_vma_cache(vma);
+		vm_start = ULONG(vma_cache + OFFSET(vm_area_struct_vm_start));
+		vm_end   = ULONG(vma_cache + OFFSET(vm_area_struct_vm_end));
+		vm_flags = ULONG(vma_cache + OFFSET(vm_area_struct_vm_flags));
+
+		p_flags = 0;
+		if (vm_flags & VM_READ)
+			p_flags |= PF_R;
+		if (vm_flags & VM_WRITE)
+			p_flags |= PF_W;
+		if (vm_flags & VM_EXEC)
+			p_flags |= PF_X;
+
+		p_offset = offset;
+		p_filesz = gcore_dumpfilter_vma_dump_size(vma);
+
+		offset += p_filesz;
+
+		gcore->elf->ops->fill_program_header(gcore->elf, PT_LOAD,
+						     p_flags, p_offset,
+						     vm_start, p_filesz,
+						     vm_end - vm_start,
+						     ELF_EXEC_PAGESIZE);
+
+		if (!gcore->elf->ops->write_program_header(gcore->elf,
+							   gcore->fp))
+			error(FATAL, "%s: write, %s\n", gcore->corename,
+			      strerror(errno));
+	}
+	progressf("done.\n");
+
+	/* Align to page. Segment needs to begin with offset multiple
+	 * of block size, typically multiple of 512 bytes, in order to
+	 * make skipped page-faulted pages as holes. See the
+	 * page-fault code below. */
+	offset =
+		gcore->elf->ops->calc_segment_offset(gcore->elf)
+		+ get_note_info_size(info);
+	offset = roundup(offset, ELF_EXEC_PAGESIZE);
+
+	if (fseek(gcore->fp, offset, SEEK_SET) < 0) {
+		error(FATAL, "%s: fseek: %s\n", gcore->corename,
+		      strerror(errno));
+	}
+
+	buffer = GETBUF(PAGE_SIZE);
+	BZERO(buffer, PAGE_SIZE);
+
+	progressf("Writing PT_LOAD segment ... \n");
+	FOR_EACH_VMA_OBJECT(vma, index, mmap, gate_vma) {
+		ulong addr, end, vm_start;
+
+		vm_start = ULONG(fill_vma_cache(vma) +
+				 OFFSET(vm_area_struct_vm_start));
+
+		end = vm_start + gcore_dumpfilter_vma_dump_size(vma);
+
+		progressf("PT_LOAD[%lu]: %lx - %lx\n", index, vm_start, end);
+
+		for (addr = vm_start; addr < end; addr += PAGE_SIZE) {
+			physaddr_t paddr;
+
+			if (uvtop_quiet(addr, &paddr)) {
+				readmem(paddr, PHYSADDR, buffer, PAGE_SIZE,
+					"readmem vma list",
+					gcore_verbose_error_handle());
+				if (fwrite(buffer, PAGE_SIZE, 1, gcore->fp)
+				    != 1)
+					error(FATAL, "%s: write: %s\n",
+					      gcore->corename,
+					      strerror(errno));
+			} else {
+				pagefaultf("page fault at %lx\n", addr);
+
+				/* Fill unavailable page-faulted pages
+				 * with 0 for ease of implementation;
+				 * to be honest, I want to avoid
+				 * restructuring program header table.
+				 *
+				 * Also, we do skip these pages by
+				 * fseek(). Recent filesystems support
+				 * sparse file that doesn't allocate
+				 * actual blocks if there are no
+				 * corresponding write; such part is
+				 * called hole. Hence, the skip works
+				 * just like a filter for page-faulted
+				 * pages.
+				 *
+				 * Note, however, that we don't reedit
+				 * program headers and these pages are
+				 * logically present on corefile as
+				 * zero-filled pages. If copying the
+				 * corefile on system that doesn't
+				 * support sparse file, resulting
+				 * corefile can be much larger than
+				 * original size.
+				 */
+				if (fseek(gcore->fp, PAGE_SIZE, SEEK_CUR) < 0) {
+					error(FATAL, "%s: fseek: %s\n",
+					      gcore->corename,
+					      strerror(errno));
+				}
+			}
+		}
+	}
+	progressf("done.\n");
+
+	gcore->flags |= GCF_SUCCESS;
+
+}
+
+static inline int
+thread_group_leader(ulong task)
+{
+	ulong group_leader;
+
+	readmem(task + GCORE_OFFSET(task_struct_group_leader), KVADDR,
+		&group_leader, sizeof(group_leader),
+		"thread_group_leader: group_leader",
+		gcore_verbose_error_handle());
+
+	return task == group_leader;
+}
+
+static int
+task_nice(ulong task)
+{
+	int static_prio;
+
+	readmem(task + GCORE_OFFSET(task_struct_static_prio), KVADDR,
+		&static_prio, sizeof(static_prio), "task_nice: static_prio",
+		gcore_verbose_error_handle());
+
+	return PRIO_TO_NICE(static_prio);
+}
+
+static void
+fill_psinfo_note(struct elf_note_info *info, struct task_context *tc,
+		 struct memelfnote *memnote)
+{
+	struct elf_prpsinfo *psinfo;
+	ulong arg_start, arg_end, parent;
+	physaddr_t paddr;
+	long state, uid, gid;
+        unsigned int i, len;
+	char *mm_cache;
+
+	psinfo = (struct elf_prpsinfo *)GETBUF(sizeof(struct elf_prpsinfo));
+        fill_note(memnote, "CORE", NT_PRPSINFO, sizeof(struct elf_prpsinfo),
+		  psinfo);
+
+        /* first copy the parameters from user space */
+	BZERO(psinfo, sizeof(struct elf_prpsinfo));
+
+	mm_cache = fill_mm_struct(task_mm(tc->task, FALSE));
+
+	arg_start = ULONG(mm_cache + GCORE_OFFSET(mm_struct_arg_start));
+	arg_end = ULONG(mm_cache + GCORE_OFFSET(mm_struct_arg_end));
+
+        len = arg_end - arg_start;
+        if (len >= ELF_PRARGSZ)
+                len = ELF_PRARGSZ-1;
+	if (uvtop(CURRENT_CONTEXT(), arg_start, &paddr, FALSE)) {
+		readmem(paddr, PHYSADDR, &psinfo->pr_psargs, len,
+			"fill_psinfo: pr_psargs", gcore_verbose_error_handle());
+	} else {
+		pagefaultf("page fault at %lx\n", arg_start);
+	}
+        for(i = 0; i < len; i++)
+                if (psinfo->pr_psargs[i] == 0)
+                        psinfo->pr_psargs[i] = ' ';
+        psinfo->pr_psargs[len] = 0;
+
+	readmem(tc->task + GCORE_OFFSET(task_struct_real_parent), KVADDR,
+		&parent, sizeof(parent), "fill_psinfo: real_parent",
+		gcore_verbose_error_handle());
+
+	psinfo->pr_ppid = ggt->task_pid(parent);
+	psinfo->pr_pid = ggt->task_pid(tc->task);
+	psinfo->pr_pgrp = ggt->task_pgrp(tc->task);
+	psinfo->pr_sid = ggt->task_session(tc->task);
+
+	readmem(tc->task + OFFSET(task_struct_state), KVADDR, &state, sizeof(state),
+		"fill_psinfo: state", gcore_verbose_error_handle());
+
+        i = state ? ffz(~state) + 1 : 0;
+        psinfo->pr_state = i;
+        psinfo->pr_sname = (i > 5) ? '.' : "RSDTZW"[i];
+        psinfo->pr_zomb = psinfo->pr_sname == 'Z';
+
+	psinfo->pr_nice = task_nice(tc->task);
+
+	readmem(tc->task + OFFSET(task_struct_flags), KVADDR, &psinfo->pr_flag,
+		sizeof(psinfo->pr_flag), "fill_psinfo: flags",
+		gcore_verbose_error_handle());
+
+	uid = ggt->task_uid(tc->task);
+	gid = ggt->task_gid(tc->task);
+
+	SET_UID(psinfo->pr_uid, (uid_t)uid);
+	SET_GID(psinfo->pr_gid, (gid_t)gid);
+
+	readmem(tc->task + OFFSET(task_struct_comm), KVADDR, &psinfo->pr_fname,
+		TASK_COMM_LEN, "fill_psinfo: comm",
+		gcore_verbose_error_handle());
+
+}
+
+#ifdef GCORE_ARCH_COMPAT
+
+static void
+compat_fill_psinfo_note(struct elf_note_info *info,
+			struct task_context *tc,
+			struct memelfnote *memnote)
+{
+	struct compat_elf_prpsinfo *psinfo;
+	ulong arg_start, arg_end, parent;
+	physaddr_t paddr;
+	long state, uid, gid;
+        unsigned int i, len;
+	char *mm_cache;
+
+	psinfo = (struct compat_elf_prpsinfo *)GETBUF(sizeof(*psinfo));
+        fill_note(memnote, "CORE", NT_PRPSINFO, sizeof(*psinfo), psinfo);
+
+        /* first copy the parameters from user space */
+	BZERO(psinfo, sizeof(struct elf_prpsinfo));
+
+	mm_cache = fill_mm_struct(task_mm(tc->task, FALSE));
+
+	arg_start = ULONG(mm_cache + GCORE_OFFSET(mm_struct_arg_start));
+	arg_end = ULONG(mm_cache + GCORE_OFFSET(mm_struct_arg_end));
+
+        len = arg_end - arg_start;
+        if (len >= ELF_PRARGSZ)
+                len = ELF_PRARGSZ-1;
+	if (uvtop(CURRENT_CONTEXT(), arg_start, &paddr, FALSE)) {
+		readmem(paddr, PHYSADDR, &psinfo->pr_psargs, len,
+			"fill_psinfo: pr_psargs", gcore_verbose_error_handle());
+	} else {
+		pagefaultf("page fault at %lx\n", arg_start);
+	}
+        for(i = 0; i < len; i++)
+                if (psinfo->pr_psargs[i] == 0)
+                        psinfo->pr_psargs[i] = ' ';
+        psinfo->pr_psargs[len] = 0;
+
+	readmem(tc->task + GCORE_OFFSET(task_struct_real_parent), KVADDR,
+		&parent, sizeof(parent), "fill_psinfo: real_parent",
+		gcore_verbose_error_handle());
+
+	psinfo->pr_ppid = ggt->task_pid(parent);
+	psinfo->pr_pid = ggt->task_pid(tc->task);
+	psinfo->pr_pgrp = ggt->task_pgrp(tc->task);
+	psinfo->pr_sid = ggt->task_session(tc->task);
+
+	readmem(tc->task + OFFSET(task_struct_state), KVADDR, &state, sizeof(state),
+		"fill_psinfo: state", gcore_verbose_error_handle());
+
+        i = state ? ffz(~state) + 1 : 0;
+        psinfo->pr_state = i;
+        psinfo->pr_sname = (i > 5) ? '.' : "RSDTZW"[i];
+        psinfo->pr_zomb = psinfo->pr_sname == 'Z';
+
+	psinfo->pr_nice = task_nice(tc->task);
+
+	readmem(tc->task + OFFSET(task_struct_flags), KVADDR, &psinfo->pr_flag,
+		sizeof(psinfo->pr_flag), "fill_psinfo: flags",
+		gcore_verbose_error_handle());
+
+	uid = ggt->task_uid(tc->task);
+	gid = ggt->task_gid(tc->task);
+
+	SET_UID(psinfo->pr_uid, (__compat_uid_t)uid);
+	SET_GID(psinfo->pr_gid, (__compat_gid_t)gid);
+
+	readmem(tc->task + OFFSET(task_struct_comm), KVADDR, &psinfo->pr_fname,
+		TASK_COMM_LEN, "fill_psinfo: comm",
+		gcore_verbose_error_handle());
+
+}
+
+#endif /* GCORE_ARCH_COMPAT */
+
+static void fill_elf_header(int phnum)
+{
+	const struct user_regset_view *view = task_user_regset_view();
+
+	gcore->elf->ops->fill_elf_header(gcore->elf,
+					 phnum < PN_XNUM ? phnum : PN_XNUM,
+					 view->e_machine, view->e_flags,
+					 view->ei_osabi);
+
+	if (gcore->elf->ops->get_e_shoff(gcore->elf))
+		gcore->elf->ops->fill_section_header(gcore->elf, phnum);
+}
+
+static void
+fill_write_thread_core_info(FILE *fp, struct task_context *tc,
+			    struct task_context *dump_tc,
+			    struct elf_note_info *info,
+			    const struct user_regset_view *view,
+			    loff_t *offset, size_t *total)
+{
+	unsigned int i;
+	char *buf;
+	struct memelfnote memnote;
+
+	/* NT_PRSTATUS is the one special case, because the regset data
+	 * goes into the pr_reg field inside the note contents, rather
+         * than being the whole note contents.  We fill the reset in here.
+         * We assume that regset 0 is NT_PRSTATUS.
+         */
+	buf = GETBUF(view->regsets[0].size);
+	view->regsets[0].get(tc, &view->regsets[0],
+			     view->regsets[0].size, buf);
+	/* We pass actual object in case of prstatus. We don't do this
+	 * in other cases. */
+	memnote.data = buf;
+	info->fill_prstatus_note(info, tc, &memnote);
+        *total += notesize(&memnote);
+	writenote(&memnote, fp, offset);
+	FREEBUF(buf);
+	FREEBUF(memnote.data);
+
+        /*
+	 * Fill in the two process-wide notes.
+         */
+	if (tc == dump_tc) {
+		info->fill_psinfo_note(info, dump_tc, &memnote);
+		info->size += notesize(&memnote);
+		writenote(&memnote, fp, offset);
+		FREEBUF(memnote.data);
+
+		info->fill_auxv_note(info, dump_tc, &memnote);
+		info->size += notesize(&memnote);
+		writenote(&memnote, fp, offset);
+		FREEBUF(memnote.data);
+
+		if (info->fill_files_note(info, dump_tc, &memnote)) {
+			info->size += notesize(&memnote);
+			writenote(&memnote, fp, offset);
+			FREEBUF(memnote.data);
+		}
+	}
+
+	for (i = 1; i < view->n; ++i) {
+		const struct user_regset *regset = &view->regsets[i];
+
+		if (!regset->core_note_type)
+			continue;
+		if (regset->active &&
+		    !regset->active(tc, regset))
+			continue;
+		buf = GETBUF(regset->size);
+		if (regset->get(tc, regset, regset->size, buf))
+			goto fail;
+
+		fill_note(&memnote, regset->name, regset->core_note_type,
+			  regset->size, buf);
+		*total += notesize(&memnote);
+		writenote(&memnote, fp, offset);
+	fail:
+		FREEBUF(buf);
+	}
+}
+
+static struct elf_note_info *elf_note_info_init(void)
+{
+	struct elf_note_info *info;
+
+	info = (struct elf_note_info *)GETBUF(sizeof(*info));
+
+#ifdef GCORE_ARCH_COMPAT
+	if (gcore_is_arch_32bit_emulation(CURRENT_CONTEXT())) {
+		info->fill_prstatus_note = compat_fill_prstatus_note;
+		info->fill_psinfo_note = compat_fill_psinfo_note;
+		info->fill_auxv_note = compat_fill_auxv_note;
+		info->fill_files_note = compat_fill_files_note;
+		return info;
+	}
+#endif
+
+	info->fill_prstatus_note = fill_prstatus_note;
+	info->fill_psinfo_note = fill_psinfo_note;
+	info->fill_auxv_note = fill_auxv_note;
+	info->fill_files_note = fill_files_note;
+
+	return info;
+}
+
+static int
+fill_write_note_info(FILE *fp, struct elf_note_info *info, int phnum,
+		     loff_t *offset)
+{
+	const struct user_regset_view *view = task_user_regset_view();
+	struct task_context *tc;
+	struct task_context *dump_tc = CURRENT_CONTEXT();
+	ulong i;
+
+	info->size = 0;
+
+	info->thread_notes = 0;
+	for (i = 0; i < view->n; i++)
+		if (view->regsets[i].core_note_type != 0)
+			++info->thread_notes;
+
+	/* Sanity check.  We rely on regset 0 being in NT_PRSTATUS,
+         * since it is our one special case.
+         */
+	if (info->thread_notes == 0 ||
+	    view->regsets[0].core_note_type != NT_PRSTATUS)
+		error(FATAL, "regset 0 is _not_ NT_PRSTATUS\n");
+
+	/*
+	 * Put dump task note information first. This is a common
+	 * convension we can see in core dump generated by linux
+	 * process core dumper and gdb gcore.
+	 */
+	fill_write_thread_core_info(fp, dump_tc, dump_tc, info, view,
+				    offset, &info->size);
+	FOR_EACH_TASK_IN_THREAD_GROUP(task_tgid(dump_tc->task), tc) {
+		if (tc != dump_tc) {
+			fill_write_thread_core_info(fp, tc, dump_tc, info,
+						    view, offset, &info->size);
+		}
+	}
+
+	return 0;
+}
+
+static int
+notesize(struct memelfnote *en)
+{
+        int sz;
+
+        sz = gcore->elf->ops->get_note_header_size(gcore->elf);
+        sz += roundup(strlen(en->name) + 1, 4);
+        sz += roundup(en->datasz, 4);
+
+        return sz;
+}
+
+static void
+fill_note(struct memelfnote *note, const char *name, int type, unsigned int sz,
+	  void *data)
+{
+        note->name = name;
+        note->type = type;
+	note->datasz = sz;
+        note->data = data;
+        return;
+}
+
+static void
+alignfile(FILE *fp, loff_t *foffset)
+{
+        static const char buffer[4] = {};
+	const size_t len = roundup(*foffset, 4) - *foffset;
+
+	if (len > 0) {
+		if (fwrite(buffer, len, 1, fp) != 1)
+			error(FATAL, "%s: write %s\n", gcore->corename,
+			      strerror(errno));
+		*foffset += (loff_t)len;
+	}
+}
+
+static void
+writenote(struct memelfnote *men, FILE *fp, loff_t *foffset)
+{
+	uint32_t n_namesz, n_descsz, n_type;
+
+	n_namesz = strlen(men->name) + 1;
+	n_descsz = men->datasz;
+	n_type = men->type;
+
+	gcore->elf->ops->fill_note_header(gcore->elf, n_namesz, n_descsz,
+					  n_type);
+
+	if (!gcore->elf->ops->write_note_header(gcore->elf, fp, foffset))
+		error(FATAL, "%s: write %s\n", gcore->corename,
+		      strerror(errno));
+
+	if (fwrite(men->name, n_namesz, 1, fp) != 1)
+		error(FATAL, "%s: write %s\n", gcore->corename,
+		      strerror(errno));
+	*foffset += n_namesz;
+
+        alignfile(fp, foffset);
+
+	if (fwrite(men->data, men->datasz, 1, fp) != 1)
+		error(FATAL, "%s: write %s\n", gcore->corename,
+		      strerror(errno));
+	*foffset += men->datasz;
+
+        alignfile(fp, foffset);
+
+}
+
+static size_t
+get_note_info_size(struct elf_note_info *info)
+{
+	return info->size;
+}
+
+ulong first_vma(ulong mmap, ulong gate_vma)
+{
+	return mmap ? mmap : gate_vma;
+}
+
+ulong next_vma(ulong this_vma, ulong gate_vma)
+{
+	ulong next;
+
+	next = ULONG(fill_vma_cache(this_vma) + OFFSET(vm_area_struct_vm_next));
+	if (next)
+		return next;
+	if (this_vma == gate_vma)
+		return 0UL;
+	return gate_vma;
+}
+
+struct task_context *next_task_context(ulong tgid, struct task_context *tc)
+{
+	const struct task_context * const end = FIRST_CONTEXT() + RUNNING_TASKS();
+
+	for (++tc; tc < end; ++tc)
+		if (task_tgid(tc->task) == tgid)
+			return tc;
+
+	return NULL;
+}
+
+static void
+fill_prstatus_note(struct elf_note_info *info, struct task_context *tc,
+		   struct memelfnote *memnote)
+{
+	struct elf_prstatus *prstatus;
+#if defined(X86) || defined(X86_64) || defined(ARM) || defined(MIPS) || defined(PPC64)
+	struct user_regs_struct *regs = (struct user_regs_struct *)memnote->data;
+#endif
+#ifdef ARM64
+	struct user_pt_regs *regs = (struct user_pt_regs *)memnote->data;
+#endif
+	ulong pending_signal_sig0, blocked_sig0, real_parent, group_leader,
+		signal, cutime,	cstime;
+
+	prstatus = (struct elf_prstatus *)GETBUF(sizeof(*prstatus));
+	memcpy(&prstatus->pr_reg, regs, sizeof(*regs));
+
+        fill_note(memnote, "CORE", NT_PRSTATUS, sizeof(*prstatus), prstatus);
+
+        /* The type of (sig[0]) is unsigned long. */
+	readmem(tc->task + OFFSET(task_struct_pending) + OFFSET(sigpending_signal),
+		KVADDR, &pending_signal_sig0, sizeof(unsigned long),
+		"fill_prstatus: sigpending_signal_sig",
+		gcore_verbose_error_handle());
+
+	readmem(tc->task + OFFSET(task_struct_blocked), KVADDR, &blocked_sig0,
+		sizeof(unsigned long), "fill_prstatus: blocked_sig0",
+		gcore_verbose_error_handle());
+
+	readmem(tc->task + OFFSET(task_struct_parent), KVADDR, &real_parent,
+		sizeof(real_parent), "fill_prstatus: real_parent",
+		gcore_verbose_error_handle());
+
+	readmem(tc->task + GCORE_OFFSET(task_struct_group_leader), KVADDR,
+		&group_leader, sizeof(group_leader),
+		"fill_prstatus: group_leader", gcore_verbose_error_handle());
+
+	prstatus->pr_info.si_signo = prstatus->pr_cursig = 0;
+        prstatus->pr_sigpend = pending_signal_sig0;
+        prstatus->pr_sighold = blocked_sig0;
+        prstatus->pr_ppid = ggt->task_pid(real_parent);
+        prstatus->pr_pid = ggt->task_pid(tc->task);
+        prstatus->pr_pgrp = ggt->task_pgrp(tc->task);
+        prstatus->pr_sid = ggt->task_session(tc->task);
+
+        if (thread_group_leader(tc->task)) {
+                struct task_cputime cputime;
+
+                /*
+                 * This is the record for the group leader.  It shows the
+                 * group-wide total, not its individual thread total.
+                 */
+                ggt->thread_group_cputime(tc->task, &cputime);
+                cputime_to_timeval(cputime.utime, &prstatus->pr_utime);
+                cputime_to_timeval(cputime.stime, &prstatus->pr_stime);
+        } else {
+		cputime_t utime, stime;
+
+		readmem(tc->task + OFFSET(task_struct_utime), KVADDR, &utime,
+			sizeof(utime), "task_struct utime",
+			gcore_verbose_error_handle());
+
+		readmem(tc->task + OFFSET(task_struct_stime), KVADDR, &stime,
+			sizeof(stime), "task_struct stime",
+			gcore_verbose_error_handle());
+
+                cputime_to_timeval(utime, &prstatus->pr_utime);
+                cputime_to_timeval(stime, &prstatus->pr_stime);
+        }
+
+	readmem(tc->task + OFFSET(task_struct_signal), KVADDR, &signal,
+		sizeof(signal), "task_struct signal", gcore_verbose_error_handle());
+
+	readmem(tc->task + GCORE_OFFSET(signal_struct_cutime), KVADDR,
+		&cutime, sizeof(cutime), "signal_struct cutime",
+		gcore_verbose_error_handle());
+
+	readmem(tc->task + GCORE_OFFSET(signal_struct_cutime), KVADDR,
+		&cstime, sizeof(cstime), "signal_struct cstime",
+		gcore_verbose_error_handle());
+
+        cputime_to_timeval(cutime, &prstatus->pr_cutime);
+        cputime_to_timeval(cstime, &prstatus->pr_cstime);
+
+	prstatus->pr_fpvalid = gcore_arch_get_fp_valid(tc);
+}
+
+#ifdef GCORE_ARCH_COMPAT
+
+static void
+compat_fill_prstatus_note(struct elf_note_info *info,
+			  struct task_context *tc,
+			  struct memelfnote *memnote)
+{
+	struct compat_elf_prstatus *prstatus;
+	compat_elf_gregset_t *regs =
+		(compat_elf_gregset_t *)memnote->data;
+	ulong pending_signal_sig0, blocked_sig0, real_parent, group_leader,
+		signal, cutime,	cstime;
+
+	prstatus = (struct compat_elf_prstatus *)GETBUF(sizeof(*prstatus));
+	memcpy(&prstatus->pr_reg, regs, sizeof(*regs));
+
+        fill_note(memnote, "CORE", NT_PRSTATUS, sizeof(*prstatus), prstatus);
+
+        /* The type of (sig[0]) is unsigned long. */
+	readmem(tc->task + OFFSET(task_struct_pending) + OFFSET(sigpending_signal),
+		KVADDR, &pending_signal_sig0, sizeof(unsigned long),
+		"fill_prstatus: sigpending_signal_sig",
+		gcore_verbose_error_handle());
+
+	readmem(tc->task + OFFSET(task_struct_blocked), KVADDR, &blocked_sig0,
+		sizeof(unsigned long), "fill_prstatus: blocked_sig0",
+		gcore_verbose_error_handle());
+
+	readmem(tc->task + OFFSET(task_struct_parent), KVADDR, &real_parent,
+		sizeof(real_parent), "fill_prstatus: real_parent",
+		gcore_verbose_error_handle());
+
+	readmem(tc->task + GCORE_OFFSET(task_struct_group_leader), KVADDR,
+		&group_leader, sizeof(group_leader),
+		"fill_prstatus: group_leader", gcore_verbose_error_handle());
+
+	prstatus->pr_info.si_signo = prstatus->pr_cursig = 0;
+        prstatus->pr_sigpend = pending_signal_sig0;
+        prstatus->pr_sighold = blocked_sig0;
+        prstatus->pr_ppid = ggt->task_pid(real_parent);
+        prstatus->pr_pid = ggt->task_pid(tc->task);
+        prstatus->pr_pgrp = ggt->task_pgrp(tc->task);
+        prstatus->pr_sid = ggt->task_session(tc->task);
+
+        if (thread_group_leader(tc->task)) {
+                struct task_cputime cputime;
+
+                /*
+                 * This is the record for the group leader.  It shows the
+                 * group-wide total, not its individual thread total.
+                 */
+                ggt->thread_group_cputime(tc->task, &cputime);
+                cputime_to_compat_timeval(cputime.utime, &prstatus->pr_utime);
+                cputime_to_compat_timeval(cputime.stime, &prstatus->pr_stime);
+        } else {
+		cputime_t utime, stime;
+
+		readmem(tc->task + OFFSET(task_struct_utime), KVADDR, &utime,
+			sizeof(utime), "task_struct utime",
+			gcore_verbose_error_handle());
+
+		readmem(tc->task + OFFSET(task_struct_stime), KVADDR, &stime,
+			sizeof(stime), "task_struct stime",
+			gcore_verbose_error_handle());
+
+                cputime_to_compat_timeval(utime, &prstatus->pr_utime);
+                cputime_to_compat_timeval(stime, &prstatus->pr_stime);
+        }
+
+	readmem(tc->task + OFFSET(task_struct_signal), KVADDR, &signal,
+		sizeof(signal), "task_struct signal",
+		gcore_verbose_error_handle());
+
+	readmem(tc->task + GCORE_OFFSET(signal_struct_cutime), KVADDR,
+		&cutime, sizeof(cutime), "signal_struct cutime",
+		gcore_verbose_error_handle());
+
+	readmem(tc->task + GCORE_OFFSET(signal_struct_cutime), KVADDR,
+		&cstime, sizeof(cstime), "signal_struct cstime",
+		gcore_verbose_error_handle());
+
+        cputime_to_compat_timeval(cutime, &prstatus->pr_cutime);
+        cputime_to_compat_timeval(cstime, &prstatus->pr_cstime);
+
+	prstatus->pr_fpvalid = gcore_arch_get_fp_valid(tc);
+}
+
+#endif /* GCORE_ARCH_COMPAT */
+
+static void
+fill_auxv_note(struct elf_note_info *info, struct task_context *tc,
+	       struct memelfnote *memnote)
+{
+	ulong *auxv;
+	int i;
+
+	auxv = (ulong *)GETBUF(GCORE_SIZE(mm_struct_saved_auxv));
+
+	readmem(task_mm(tc->task, FALSE) +
+		GCORE_OFFSET(mm_struct_saved_auxv), KVADDR, auxv,
+		GCORE_SIZE(mm_struct_saved_auxv), "fill_auxv_note",
+		gcore_verbose_error_handle());
+
+	i = 0;
+	do
+		i += 2;
+	while (auxv[i - 2] != AT_NULL);
+
+	fill_note(memnote, "CORE", NT_AUXV, i * sizeof(ulong), auxv);
+
+}
+
+#ifdef GCORE_ARCH_COMPAT
+
+static void
+compat_fill_auxv_note(struct elf_note_info *info,
+		      struct task_context *tc,
+		      struct memelfnote *memnote)
+{
+	uint32_t *auxv;
+	int i;
+
+	auxv = (uint32_t *)GETBUF(GCORE_SIZE(mm_struct_saved_auxv));
+
+	readmem(task_mm(tc->task, FALSE) +
+		GCORE_OFFSET(mm_struct_saved_auxv), KVADDR, auxv,
+		GCORE_SIZE(mm_struct_saved_auxv), "fill_auxv_note32",
+		gcore_verbose_error_handle());
+
+	i = 0;
+	do
+		i += 2;
+	while (auxv[i - 2] != AT_NULL);
+
+	fill_note(memnote, "CORE", NT_AUXV, i * sizeof(uint32_t), auxv);
+}
+
+#endif /* GCORE_ARCH_COMPAT */
+
+static int
+fill_files_note(struct elf_note_info *info, struct task_context *tc,
+	       struct memelfnote *memnote)
+{
+	ulong mmap, gate_vma, vma, vm_start, vm_end, vm_file, vm_pgoff, dentry, vfsmnt;
+	unsigned count, map_count, size, names_ofs, remaining, n, index;
+	ulong *data, *start_end_ofs;
+	char *name_base, *name_curpos, *file_buf, *mm_cache;
+	char buf[BUFSIZE];
+
+	BZERO(buf, BUFSIZE);
+
+	mm_cache = fill_mm_struct(task_mm(CURRENT_TASK(), TRUE));
+	if (!mm_cache) {
+		error(WARNING, "The user memory space does not exist.\n");
+		return FALSE;
+	}
+
+	mmap = ULONG(mm_cache + OFFSET(mm_struct_mmap));
+	gate_vma = gcore_arch_get_gate_vma();
+
+	/* *Estimated* file count and total data size needed */
+	map_count = count = INT(mm_cache + GCORE_OFFSET(mm_struct_map_count));
+	if (count > UINT_MAX / 64) {
+		error(WARNING, "Map count too big.\n");
+		return FALSE;
+	}
+	size = count * 64;
+	names_ofs = (2 + 3 * count) * sizeof(data[0]);
+
+	/* paranoia check */
+	if (size >= ELF_EXEC_PAGESIZE * 1024) {
+		error(WARNING, "Size required for file_note is too big.\n");
+		return FALSE;
+	}
+	size = PAGE_ALIGN(size);
+	data = (ulong *)GETBUF(size);
+	BZERO(data, size);
+
+	start_end_ofs = data + 2;
+	name_base = name_curpos = ((char *)data) + names_ofs;
+	remaining = size - names_ofs;
+	count = 0;
+
+	FOR_EACH_VMA_OBJECT(vma, index, mmap, gate_vma) {
+		char *vma_cache;
+
+		if (!IS_KVADDR(vma))
+			continue;
+
+		vma_cache = fill_vma_cache(vma);
+		vm_start = ULONG(vma_cache + OFFSET(vm_area_struct_vm_start));
+		vm_end = ULONG(vma_cache + OFFSET(vm_area_struct_vm_end));
+		vm_file = ULONG(vma_cache + OFFSET(vm_area_struct_vm_file));
+		vm_pgoff = ULONG(vma_cache + OFFSET(vm_area_struct_vm_pgoff));
+
+		if (!vm_file)
+			continue;
+
+		file_buf = fill_file_cache(vm_file);
+		dentry = ULONG(file_buf + OFFSET(file_f_dentry));
+		if (dentry) {
+			fill_dentry_cache(dentry);
+			if (VALID_MEMBER(file_f_vfsmnt)) {
+				vfsmnt = ULONG(file_buf + OFFSET(file_f_vfsmnt));
+				get_pathname(dentry, buf, BUFSIZE, 1, vfsmnt);
+			} else {
+				get_pathname(dentry, buf, BUFSIZE, 1, 0);
+			}
+		}
+
+		/* get_pathname() fills at the end, move name down */
+		n = strlen(buf)*sizeof(char) + 1;
+		remaining -= n;
+		memmove(name_curpos, buf, n);
+		progressf("FILE %s\n", name_curpos);
+		name_curpos += n;
+
+		*start_end_ofs++ = vm_start;
+		*start_end_ofs++ = vm_end;
+		*start_end_ofs++ = vm_pgoff;
+		count++;
+	}
+
+	/* Now we know exact count of files, can store it */
+	data[0] = count;
+	data[1] = size;
+
+	/*
+	 * Count usually is less than map_count,
+	 * we need to move filenames down.
+	 */
+	n = map_count - count;
+	if (n != 0) {
+		unsigned shift_bytes = n * 3 * sizeof(data[0]);
+		memmove(name_base - shift_bytes, name_base,
+			name_curpos - name_base);
+		name_curpos -= shift_bytes;
+	}
+
+	size = name_curpos - (char *)data;
+	fill_note(memnote, "CORE", NT_FILE, size, data);
+
+	return TRUE;
+}
+
+#ifdef GCORE_ARCH_COMPAT
+static int
+compat_fill_files_note(struct elf_note_info *info, struct task_context *tc,
+		       struct memelfnote *memnote)
+{
+	ulong mmap, gate_vma, vma, vm_start, vm_end, vm_file, vm_pgoff, dentry, vfsmnt;
+	unsigned count, map_count, size, names_ofs, remaining, n, index;
+	unsigned int *data, *start_end_ofs;
+	char *name_base, *name_curpos, *file_buf, *mm_cache;
+	char buf[BUFSIZE];
+
+	BZERO(buf, BUFSIZE);
+
+	mm_cache = fill_mm_struct(task_mm(CURRENT_TASK(), TRUE));
+	if (!mm_cache) {
+		error(WARNING, "The user memory space does not exist.\n");
+		return FALSE;
+	}
+
+	mmap = ULONG(mm_cache + OFFSET(mm_struct_mmap));
+	gate_vma = gcore_arch_get_gate_vma();
+
+	/* *Estimated* file count and total data size needed */
+	map_count = count = INT(mm_cache + GCORE_OFFSET(mm_struct_map_count));
+	if (count > UINT_MAX / 64) {
+		error(WARNING, "Map count too big.\n");
+		return FALSE;
+	}
+	size = count * 64;
+	names_ofs = (2 + 3 * count) * sizeof(data[0]);
+
+	/* paranoia check */
+	if (size >= ELF_EXEC_PAGESIZE * 1024) {
+		error(WARNING, "Size required for file_note is too big.\n");
+		return FALSE;
+	}
+	size = PAGE_ALIGN(size);
+	data = (unsigned int *)GETBUF(size);
+	BZERO(data, size);
+
+	start_end_ofs = data + 2;
+	name_base = name_curpos = ((char *)data) + names_ofs;
+	remaining = size - names_ofs;
+	count = 0;
+
+	FOR_EACH_VMA_OBJECT(vma, index, mmap, gate_vma) {
+		char *vma_cache;
+
+		if (!IS_KVADDR(vma))
+			continue;
+
+		vma_cache = fill_vma_cache(vma);
+		vm_start = ULONG(vma_cache + OFFSET(vm_area_struct_vm_start));
+		vm_end = ULONG(vma_cache + OFFSET(vm_area_struct_vm_end));
+		vm_file = ULONG(vma_cache + OFFSET(vm_area_struct_vm_file));
+		vm_pgoff = ULONG(vma_cache + OFFSET(vm_area_struct_vm_pgoff));
+
+		if (!vm_file)
+			continue;
+
+		file_buf = fill_file_cache(vm_file);
+		dentry = ULONG(file_buf + OFFSET(file_f_dentry));
+		if (dentry) {
+			fill_dentry_cache(dentry);
+			if (VALID_MEMBER(file_f_vfsmnt)) {
+				vfsmnt = ULONG(file_buf + OFFSET(file_f_vfsmnt));
+				get_pathname(dentry, buf, BUFSIZE, 1, vfsmnt);
+			} else {
+				get_pathname(dentry, buf, BUFSIZE, 1, 0);
+			}
+		}
+
+		/* get_pathname() fills at the end, move name down */
+		n = strlen(buf)*sizeof(char) + 1;
+		remaining -= n;
+		memmove(name_curpos, buf, n);
+		progressf("FILE %s\n", name_curpos);
+		name_curpos += n;
+
+		*start_end_ofs++ = vm_start;
+		*start_end_ofs++ = vm_end;
+		*start_end_ofs++ = vm_pgoff;
+		count++;
+	}
+
+	/* Now we know exact count of files, can store it */
+	data[0] = count;
+	data[1] = size;
+
+	/*
+	 * Count usually is less than map_count,
+	 * we need to move filenames down.
+	 */
+	n = map_count - count;
+	if (n != 0) {
+		unsigned shift_bytes = n * 3 * sizeof(data[0]);
+		memmove(name_base - shift_bytes, name_base,
+			name_curpos - name_base);
+		name_curpos -= shift_bytes;
+	}
+
+	size = name_curpos - (char *)data;
+	fill_note(memnote, "CORE", NT_FILE, size, data);
+
+	return TRUE;
+}
+#endif /* GCORE_ARCH_COMPAT */
+
+static int uvtop_quiet(ulong vaddr, physaddr_t *paddr)
+{
+	FILE *saved_fp = fp;
+	int page_present;
+
+	/* uvtop() with verbose FALSE returns wrong physical address
+	 * for gate_vma. The problem is that kvtop() wrongly thinks of
+	 * the fixed address 0xffffffffff600000 as the one that
+	 * belongs to direct mapping region and calculates the result
+	 * by substracting offset of direct-mapping space from the
+	 * fixed address. However, it's necessary to do paging to get
+	 * correct physical address.
+	 *
+	 * uvtop() does paging if verbose == TRUE. Then, it retuns
+	 * correct physical address.
+	 *
+	 * Next output of vtop clarifies this bug, where the first
+	 * PHYSICAL showing 0x7f600000 is wrong one and the PHYSICAL
+	 * in the last line showing 0x1c08000 is correct one.
+	 *
+	 * crash> vtop 0xffffffffff600000
+	 * VIRTUAL           PHYSICAL        
+	 * ffffffffff600000  7f600000        
+	 *
+	 * PML4 DIRECTORY: ffffffff81a85000
+	 * PAGE DIRECTORY: 1a87067
+	 *    PUD: 1a87ff8 => 1a88067
+	 *    PMD: 1a88fd8 => 28049067
+	 *    PTE: 28049000 => 1c08165
+	 *   PAGE: 1c08000
+	 *
+	 *   PTE    PHYSICAL  FLAGS
+	 * 1c08165   1c08000  (PRESENT|USER|ACCESSED|DIRTY|GLOBAL)
+	 *
+	 *       PAGE        PHYSICAL      MAPPING       INDEX CNT FLAGS
+	 * ffffea00000621c0   1c08000                0        0  1 20000000000400
+	 *
+	 * The remaining problem is that if specifying TRUE to
+	 * verbose, same information is displayed during gcore
+	 * processing. To avoid this, we assign the file pointer to
+	 * /dev/null to fp during call of uvtop().
+	 */
+	fp = pc->nullfp;
+	page_present = uvtop(CURRENT_CONTEXT(), vaddr, paddr, TRUE);
+	fp = saved_fp;
+
+	return page_present;
+}

--- a/extensions/libgcore/gcore_coredump_table.c
+++ b/extensions/libgcore/gcore_coredump_table.c
@@ -1,0 +1,460 @@
+/* gcore_coredump_table.c -- core analysis suite
+ *
+ * Copyright (C) 2010, 2011 FUJITSU LIMITED
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <defs.h>
+#include <gcore_defs.h>
+
+static unsigned int get_inode_i_nlink_v0(ulong file);
+static unsigned int get_inode_i_nlink_v19(ulong file);
+static pid_t pid_nr_ns(ulong pid, ulong ns);
+static int pid_alive(ulong task);
+static int __task_pid_nr_ns(ulong task, enum pid_type type);
+static inline pid_t task_pid(ulong task);
+static inline pid_t process_group(ulong task);
+static inline pid_t task_session(ulong task);
+static inline pid_t task_pid_vnr(ulong task);
+static inline pid_t task_pgrp_vnr(ulong task);
+static inline pid_t task_session_vnr(ulong task);
+static void
+thread_group_cputime_v0(ulong task, struct task_cputime *cputime);
+static void
+thread_group_cputime_v22(ulong task, struct task_cputime *cputime);
+static inline __kernel_uid_t task_uid_v0(ulong task);
+static inline __kernel_uid_t task_uid_v28(ulong task);
+static inline __kernel_gid_t task_gid_v0(ulong task);
+static inline __kernel_gid_t task_gid_v28(ulong task);
+
+void gcore_coredump_table_init(void)
+{
+	/*
+         * struct path was introduced at v2.6.19, where f_dentry
+         * member of struct file was replaced by f_path member.
+	 *
+	 * See vfs_init() to know why this condition is chosen.
+	 *
+	 * See commit 0f7fc9e4d03987fe29f6dd4aa67e4c56eb7ecb05.
+	 */
+	if (VALID_MEMBER(file_f_path))
+		ggt->get_inode_i_nlink = get_inode_i_nlink_v19;
+	else
+		ggt->get_inode_i_nlink = get_inode_i_nlink_v0;
+
+	/*
+	 * task_pid_vnr() and relevant helpers were introduced at
+	 * v2.6.23, while pid_namespace itself was introduced prior to
+	 * that at v2.6.19.
+	 *
+	 * We've choosed here the former commit because implemented
+	 * enough to provide pid facility was the period when the
+	 * former patches were committed.
+	 *
+	 * We've chosen symbol ``pid_nr_ns'' because it is just a
+	 * unique function that is not defined as static inline.
+	 *
+	 * See commit 7af5729474b5b8ad385adadab78d6e723e7655a3.
+	 */
+	if (symbol_exists("pid_nr_ns")) {
+		ggt->task_pid = task_pid_vnr;
+		ggt->task_pgrp = task_pgrp_vnr;
+		ggt->task_session = task_session_vnr;
+	} else {
+		ggt->task_pid = task_pid;
+		ggt->task_pgrp = process_group;
+		ggt->task_session = task_session;
+	}
+
+	/*
+	 * The way of tracking cputime changed when CFS was introduced
+	 * at v2.6.23, which can be distinguished by checking whether
+	 * se member of task_struct structure exist or not.
+	 *
+	 * See commit 20b8a59f2461e1be911dce2cfafefab9d22e4eee.
+	 */
+	if (GCORE_VALID_MEMBER(task_struct_se))
+		ggt->thread_group_cputime = thread_group_cputime_v22;
+	else
+		ggt->thread_group_cputime = thread_group_cputime_v0;
+
+        /*
+	 * Credidentials feature was introduced at v2.6.28 where uid
+	 * and gid members were moved into cred member of struct
+	 * task_struct that was newly introduced.
+	 *
+         * See commit b6dff3ec5e116e3af6f537d4caedcad6b9e5082a.
+	 */
+	if (GCORE_VALID_MEMBER(task_struct_cred)) {
+		ggt->task_uid = task_uid_v28;
+		ggt->task_gid = task_gid_v28;
+	} else {
+		ggt->task_uid = task_uid_v0;
+		ggt->task_gid = task_gid_v0;
+	}
+
+}
+
+static unsigned int get_inode_i_nlink_v0(ulong file)
+{
+	ulong d_entry, d_inode;
+	unsigned int i_nlink;
+
+	readmem(file + OFFSET(file_f_dentry), KVADDR, &d_entry, sizeof(d_entry),
+		"get_inode_i_nlink_v0: d_entry", gcore_verbose_error_handle());
+
+	readmem(d_entry + OFFSET(dentry_d_inode), KVADDR, &d_inode,
+		sizeof(d_inode), "get_inode_i_nlink_v0: d_inode",
+		gcore_verbose_error_handle());
+
+	readmem(d_inode + GCORE_OFFSET(inode_i_nlink), KVADDR, &i_nlink,
+		sizeof(i_nlink), "get_inode_i_nlink_v0: i_nlink",
+		gcore_verbose_error_handle());
+
+	return i_nlink;
+}
+
+static unsigned int get_inode_i_nlink_v19(ulong file)
+{
+	ulong d_entry, d_inode;
+	unsigned int i_nlink;
+
+	readmem(file + OFFSET(file_f_path) + OFFSET(path_dentry), KVADDR,
+		&d_entry, sizeof(d_entry), "get_inode_i_nlink_v19: d_entry",
+		gcore_verbose_error_handle());
+
+	readmem(d_entry + OFFSET(dentry_d_inode), KVADDR, &d_inode, sizeof(d_inode),
+		"get_inode_i_nlink_v19: d_inode", gcore_verbose_error_handle());
+
+	readmem(d_inode + GCORE_OFFSET(inode_i_nlink), KVADDR, &i_nlink,
+		sizeof(i_nlink), "get_inode_i_nlink_v19: i_nlink",
+		gcore_verbose_error_handle());
+
+	return i_nlink;
+}
+
+static inline pid_t
+task_pid(ulong task)
+{
+	return task_to_context(task)->pid;
+}
+
+static inline pid_t
+process_group(ulong task)
+{
+	ulong signal;
+	pid_t pgrp;
+
+	readmem(task + OFFSET(task_struct_signal), KVADDR, &signal,
+		sizeof(signal), "process_group: signal", gcore_verbose_error_handle());
+
+	readmem(signal + GCORE_OFFSET(signal_struct_pgrp), KVADDR, &pgrp,
+		sizeof(pgrp), "process_group: pgrp", gcore_verbose_error_handle());
+
+	return pgrp;
+}
+
+static inline pid_t
+task_session(ulong task)
+{
+	ulong signal;
+	pid_t session;
+
+	readmem(task + OFFSET(task_struct_signal), KVADDR, &signal,
+		sizeof(signal), "process_group: signal", gcore_verbose_error_handle());
+
+	readmem(signal + GCORE_OFFSET(signal_struct_session), KVADDR,
+		&session, sizeof(session), "task_session: session",
+		gcore_verbose_error_handle());
+
+	return session;
+}
+
+static pid_t
+pid_nr_ns(ulong pid, ulong ns)
+{
+	ulong upid;
+	unsigned int ns_level, pid_level;
+	pid_t nr = 0;
+
+	readmem(ns + GCORE_OFFSET(pid_namespace_level), KVADDR, &ns_level,
+		sizeof(ns_level), "pid_nr_ns: ns_level", gcore_verbose_error_handle());
+
+	readmem(pid + GCORE_OFFSET(pid_level), KVADDR, &pid_level,
+		sizeof(pid_level), "pid_nr_ns: pid_level", gcore_verbose_error_handle());
+
+        if (pid && ns_level <= pid_level) {
+		ulong upid_ns;
+
+		upid = pid + OFFSET(pid_numbers) + SIZE(upid) * ns_level;
+
+		readmem(upid + OFFSET(upid_ns), KVADDR, &upid_ns,
+			sizeof(upid_ns), "pid_nr_ns: upid_ns",
+			gcore_verbose_error_handle());
+
+		if (upid_ns == ns)
+			readmem(upid + OFFSET(upid_nr), KVADDR, &nr,
+				sizeof(ulong), "pid_nr_ns: upid_nr",
+				gcore_verbose_error_handle());
+        }
+
+        return nr;
+}
+
+static int
+__task_pid_nr_ns(ulong task, enum pid_type type)
+{
+	ulong nsproxy, ns;
+	int nr = 0;
+
+	readmem(task + OFFSET(task_struct_nsproxy), KVADDR, &nsproxy,
+		sizeof(nsproxy), "__task_pid_nr_ns: nsproxy",
+		gcore_verbose_error_handle());
+
+	readmem(nsproxy + GCORE_OFFSET(nsproxy_pid_ns), KVADDR, &ns,
+		sizeof(ns), "__task_pid_nr_ns: ns", gcore_verbose_error_handle());
+
+	if (pid_alive(task)) {
+		ulong pids_type_pid, signal;
+
+                if (type != PIDTYPE_PID)
+			readmem(task + MEMBER_OFFSET("task_struct",
+						     "group_leader"),
+				KVADDR, &task, sizeof(ulong),
+				"__task_pid_nr_ns: group_leader",
+				gcore_verbose_error_handle());
+
+		if (VALID_MEMBER(task_struct_pids))
+			readmem(task + OFFSET(task_struct_pids) +
+				type * SIZE(pid_link) + OFFSET(pid_link_pid),
+				KVADDR, &pids_type_pid,
+				sizeof(pids_type_pid),
+				"__task_pid_nr_ns: pids_type_pid",
+				gcore_verbose_error_handle());
+		else
+			if (type == PIDTYPE_PID)
+				readmem(task + GCORE_OFFSET(task_struct_thread_pid),
+					KVADDR, &pids_type_pid,
+					sizeof(pids_type_pid),
+					"__task_pid_nr_ns: pids_type_pid",
+					gcore_verbose_error_handle());
+			else {
+				readmem(task + OFFSET(task_struct_signal),
+					KVADDR, &signal,
+					sizeof(signal),
+					"__task_pid_nr_ns: signal",
+					gcore_verbose_error_handle());
+
+				readmem(signal + GCORE_OFFSET(signal_struct_pids) +
+					type * sizeof(void *),
+					KVADDR, &pids_type_pid,
+					sizeof(pids_type_pid),
+					"__task_pid_nr_ns: pids_type_pid",
+					gcore_verbose_error_handle());
+			}
+
+		nr = pid_nr_ns(pids_type_pid, ns);
+        }
+
+        return nr;
+}
+
+static inline pid_t
+task_pid_vnr(ulong task)
+{
+	return __task_pid_nr_ns(task, PIDTYPE_PID);
+}
+
+static inline pid_t
+task_pgrp_vnr(ulong task)
+{
+        return __task_pid_nr_ns(task, PIDTYPE_PGID);
+}
+
+static inline pid_t
+task_session_vnr(ulong task)
+{
+        return __task_pid_nr_ns(task, PIDTYPE_SID);
+}
+
+static void
+thread_group_cputime_v0(ulong task, struct task_cputime *cputime)
+{
+	ulong signal;
+	ulong utime, signal_utime, stime, signal_stime;
+
+	readmem(task + OFFSET(task_struct_signal), KVADDR, &signal,
+		sizeof(signal), "thread_group_cputime_v0: signal",
+		gcore_verbose_error_handle());
+
+	readmem(task + OFFSET(task_struct_utime), KVADDR, &utime,
+		sizeof(utime), "thread_group_cputime_v0: utime",
+		gcore_verbose_error_handle());
+
+	readmem(signal + GCORE_OFFSET(signal_struct_utime), KVADDR,
+		&signal_utime, sizeof(signal_utime),
+		"thread_group_cputime_v0: signal_utime",
+		gcore_verbose_error_handle());
+
+	readmem(task + OFFSET(task_struct_stime), KVADDR, &stime,
+		sizeof(stime), "thread_group_cputime_v0: stime",
+		gcore_verbose_error_handle());
+
+	readmem(signal + GCORE_OFFSET(signal_struct_stime), KVADDR,
+		&signal_stime, sizeof(signal_stime),
+		"thread_group_cputime_v0: signal_stime",
+		gcore_verbose_error_handle());
+
+	cputime->utime = utime + signal_utime;
+	cputime->stime = stime + signal_stime;
+	cputime->sum_exec_runtime = 0;
+
+}
+
+static void
+thread_group_cputime_v22(ulong task, struct task_cputime *times)
+{
+	struct task_context *tc;
+	ulong sighand, signal, signal_utime, signal_stime;
+	uint64_t sum_sched_runtime;
+
+	*times = INIT_CPUTIME;
+
+	readmem(task + OFFSET(task_struct_sighand), KVADDR, &sighand,
+		sizeof(sighand), "thread_group_cputime_v22: sighand",
+		gcore_verbose_error_handle());
+
+	if (!sighand)
+		goto out;
+
+	readmem(task + OFFSET(task_struct_signal), KVADDR, &signal,
+		sizeof(signal), "thread_group_cputime_v22: signal",
+		gcore_verbose_error_handle());
+
+	FOR_EACH_TASK_IN_THREAD_GROUP(task_tgid(CURRENT_TASK()), tc) {
+		ulong utime, stime;
+		uint64_t sum_exec_runtime;
+
+		readmem(tc->task + OFFSET(task_struct_utime), KVADDR,
+			&utime,	sizeof(utime),
+			"thread_group_cputime_v22: utime",
+			gcore_verbose_error_handle());
+
+		readmem(tc->task + OFFSET(task_struct_stime), KVADDR,
+			&stime, sizeof(stime),
+			"thread_group_cputime_v22: stime",
+			gcore_verbose_error_handle());
+
+		readmem(tc->task + GCORE_OFFSET(task_struct_se) +
+			GCORE_OFFSET(sched_entity_sum_exec_runtime),
+			KVADDR,	&sum_exec_runtime,
+			sizeof(sum_exec_runtime),
+			"thread_group_cputime_v22: sum_exec_runtime",
+			gcore_verbose_error_handle());
+
+		times->utime = cputime_add(times->utime, utime);
+		times->stime = cputime_add(times->stime, stime);
+		times->sum_exec_runtime += sum_exec_runtime;
+	}
+
+	readmem(signal + GCORE_OFFSET(signal_struct_utime), KVADDR,
+		&signal_utime, sizeof(signal_utime),
+		"thread_group_cputime_v22: signal_utime", gcore_verbose_error_handle());
+
+	readmem(signal + GCORE_OFFSET(signal_struct_stime), KVADDR,
+		&signal_stime, sizeof(signal_stime),
+		"thread_group_cputime_v22: signal_stime", gcore_verbose_error_handle());
+
+	readmem(signal + GCORE_OFFSET(signal_struct_sum_sched_runtime),
+		KVADDR, &sum_sched_runtime, sizeof(sum_sched_runtime),
+		"thread_group_cputime_v22: sum_sched_runtime",
+		gcore_verbose_error_handle());
+
+	times->utime = cputime_add(times->utime, signal_utime);
+	times->stime = cputime_add(times->stime, signal_stime);
+	times->sum_exec_runtime += sum_sched_runtime;
+
+out:
+	return;
+}
+
+static inline __kernel_uid_t
+task_uid_v0(ulong task)
+{
+	__kernel_uid_t uid;
+
+	readmem(task + GCORE_OFFSET(task_struct_uid), KVADDR, &uid,
+		sizeof(uid), "task_uid_v0: uid", gcore_verbose_error_handle());
+
+	return uid;
+}
+
+static inline __kernel_uid_t
+task_uid_v28(ulong task)
+{
+	ulong cred;
+	__kernel_uid_t uid;
+
+	readmem(task + GCORE_OFFSET(task_struct_real_cred), KVADDR, &cred,
+		sizeof(cred), "task_uid_v28: real_cred", gcore_verbose_error_handle());
+
+	readmem(cred + GCORE_OFFSET(cred_uid), KVADDR, &uid, sizeof(uid),
+		"task_uid_v28: uid", gcore_verbose_error_handle());
+
+	return uid;
+}
+
+static inline __kernel_gid_t
+task_gid_v0(ulong task)
+{
+	__kernel_gid_t gid;
+
+	readmem(task + GCORE_OFFSET(task_struct_gid), KVADDR, &gid,
+		sizeof(gid), "task_gid_v0: gid", gcore_verbose_error_handle());
+
+	return gid;
+}
+
+static inline __kernel_gid_t
+task_gid_v28(ulong task)
+{
+	ulong cred;
+	__kernel_gid_t gid;
+
+	readmem(task + GCORE_OFFSET(task_struct_real_cred), KVADDR, &cred,
+		sizeof(cred), "task_gid_v28: real_cred", gcore_verbose_error_handle());
+
+	readmem(cred + GCORE_OFFSET(cred_gid), KVADDR, &gid, sizeof(gid),
+		"task_gid_v28: gid", gcore_verbose_error_handle());
+
+	return gid;
+}
+
+static int
+pid_alive(ulong task)
+{
+	pid_t pid;
+
+	if (VALID_MEMBER(task_struct_pids))
+		readmem(task + OFFSET(task_struct_pids) +
+			PIDTYPE_PID * SIZE(pid_link) + OFFSET(pid_link_pid),
+			KVADDR, &pid, sizeof(pid),
+			"pid_alive",
+			gcore_verbose_error_handle());
+	else
+		readmem(task + GCORE_OFFSET(task_struct_thread_pid),
+			KVADDR, &pid, sizeof(pid),
+			"task_struct.thread_pid",
+			gcore_verbose_error_handle());
+
+        return !!pid;
+}

--- a/extensions/libgcore/gcore_defs.h
+++ b/extensions/libgcore/gcore_defs.h
@@ -1,0 +1,1297 @@
+/* gcore_defs.h -- core analysis suite
+ *
+ * Copyright (C) 2010 FUJITSU LIMITED
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+#ifndef GCORE_DEFS_H_
+#define GCORE_DEFS_H_
+
+#include <stdio.h>
+#include <elf.h>
+
+#if defined(X86_64) || defined(ARM64)
+#define GCORE_ARCH_COMPAT 1
+#endif
+
+#ifdef X86_64
+#include <gcore_compat_x86.h>
+#endif
+
+#ifdef ARM64
+#include <gcore_compat_arm.h>
+#endif
+
+#define PN_XNUM 0xffff
+
+#define ELF_CORE_EFLAGS 0
+
+#ifdef X86_64
+#define ELF_EXEC_PAGESIZE 4096
+
+#define ELF_MACHINE EM_X86_64
+#define ELF_OSABI ELFOSABI_NONE
+
+#define ELF_CLASS ELFCLASS64
+#define ELF_DATA ELFDATA2LSB
+#define ELF_ARCH EM_X86_64
+
+#define Elf_Half Elf64_Half
+#define Elf_Word Elf64_Word
+#define Elf_Off Elf64_Off
+
+#define Elf_Ehdr Elf64_Ehdr
+#define Elf_Phdr Elf64_Phdr
+#define Elf_Shdr Elf64_Shdr
+#define Elf_Nhdr Elf64_Nhdr
+#endif
+
+#ifdef X86
+#define ELF_EXEC_PAGESIZE 4096
+
+#define ELF_MACHINE EM_386
+#define ELF_OSABI ELFOSABI_NONE
+
+#define ELF_CLASS ELFCLASS32
+#define ELF_DATA ELFDATA2LSB
+#define ELF_ARCH EM_386
+
+#define Elf_Half Elf32_Half
+#define Elf_Word Elf32_Word
+#define Elf_Off Elf32_Off
+
+#define Elf_Ehdr Elf32_Ehdr
+#define Elf_Phdr Elf32_Phdr
+#define Elf_Shdr Elf32_Shdr
+#define Elf_Nhdr Elf32_Nhdr
+#endif
+
+#ifdef ARM
+#define ELF_EXEC_PAGESIZE 4096
+
+#define ELF_MACHINE EM_ARM
+#define ELF_OSABI ELFOSABI_NONE
+
+#define ELF_CLASS ELFCLASS32
+#define ELF_DATA ELFDATA2LSB
+#define ELF_ARCH EM_ARM
+
+#define Elf_Half Elf32_Half
+#define Elf_Word Elf32_Word
+#define Elf_Off Elf32_Off
+
+#define Elf_Ehdr Elf32_Ehdr
+#define Elf_Phdr Elf32_Phdr
+#define Elf_Shdr Elf32_Shdr
+#define Elf_Nhdr Elf32_Nhdr
+#endif
+
+#ifdef MIPS
+#define ELF_EXEC_PAGESIZE 4096
+
+#define ELF_MACHINE EM_MIPS
+#define ELF_OSABI ELFOSABI_NONE
+
+#define ELF_CLASS ELFCLASS32
+#define ELF_DATA ELFDATA2LSB
+#define ELF_ARCH EM_MIPS
+
+#define Elf_Half Elf32_Half
+#define Elf_Word Elf32_Word
+#define Elf_Off Elf32_Off
+
+#define Elf_Ehdr Elf32_Ehdr
+#define Elf_Phdr Elf32_Phdr
+#define Elf_Shdr Elf32_Shdr
+#define Elf_Nhdr Elf32_Nhdr
+#endif
+
+#ifdef ARM64
+#define ELF_EXEC_PAGESIZE PAGESIZE()
+
+#define ELF_MACHINE EM_AARCH64
+#define ELF_OSABI ELFOSABI_NONE
+
+#define ELF_CLASS ELFCLASS64
+#define ELF_DATA ELFDATA2LSB
+#define ELF_ARCH EM_AARCH64
+
+#define Elf_Half Elf64_Half
+#define Elf_Word Elf64_Word
+#define Elf_Off Elf64_Off
+
+#define Elf_Ehdr Elf64_Ehdr
+#define Elf_Phdr Elf64_Phdr
+#define Elf_Shdr Elf64_Shdr
+#define Elf_Nhdr Elf64_Nhdr
+
+#ifndef NT_ARM_TLS
+#define NT_ARM_TLS      0x401           /* ARM TLS register */
+#endif
+#endif
+
+#ifdef PPC64
+#define ELF_EXEC_PAGESIZE PAGESIZE()
+
+#define ELF_MACHINE EM_PPC64
+#define ELF_OSABI ELFOSABI_NONE
+
+#define ELF_CLASS ELFCLASS64
+
+#ifndef ELF_DATA
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+#define ELF_DATA ELFDATA2LSB
+#else
+#define ELF_DATA ELFDATA2MSB
+#endif
+#endif
+
+#define ELF_ARCH EM_PPC64
+
+#define Elf_Half Elf64_Half
+#define Elf_Word Elf64_Word
+#define Elf_Off Elf64_Off
+
+#define Elf_Ehdr Elf64_Ehdr
+#define Elf_Phdr Elf64_Phdr
+#define Elf_Shdr Elf64_Shdr
+#define Elf_Nhdr Elf64_Nhdr
+#endif
+
+#ifndef NT_FILE
+#define NT_FILE 0x46494c45
+#endif
+
+#define PAGE_ALIGN(X) roundup(X, ELF_EXEC_PAGESIZE)
+
+#ifdef divideup
+#undef divideup
+#endif
+#define divideup(x, y)  (((x) + ((y) - 1)) / (y))
+
+/*
+ * gcore_regset.c
+ *
+ * The regset interface is fully borrowed from the library with the
+ * same name in kernel used in the implementation of collecting note
+ * information. See include/regset.h in detail.
+ */
+struct user_regset;
+struct task_context;
+
+/**
+ * user_regset_active_fn - type of @active function in &struct user_regset
+ * @target:	thread being examined
+ * @regset:	task context being examined
+ *
+ * Return TRUE if there is an interesting resource.
+ * Return FALSE otherwise.
+ */
+typedef int user_regset_active_fn(struct task_context *target,
+				  const struct user_regset *regset);
+
+/**
+ * user_regset_get_fn - type of @get function in &struct user_regset
+ * @target:	task context being examined
+ * @regset:	regset being examined
+ * @size:	amount of data to copy, in bytes
+ * @buf:	if a user-space pointer to copy into
+ *
+ * Fetch register values. Return TRUE on success and FALSE otherwise.
+ * The @size is in bytes.
+ */
+typedef int user_regset_get_fn(struct task_context *target,
+			       const struct user_regset *regset,
+			       unsigned int size,
+			       void *buf);
+
+struct elf_thread_core_info;
+
+/**
+ * user_regset_callback_fn - type of @callback function in &struct user_regset
+ * @t:   thread core information
+ * @regset:	regset being examined
+ *
+ * Edit thread core information contained in @t in terms of @regset.
+ * This call is optional; the pointer is %NULL if there is no requirement to
+ * edit.
+ */
+typedef void user_regset_callback_fn(struct elf_thread_core_info *t,
+				     const struct user_regset *regset);
+
+/**
+ * struct user_regset - accessible thread CPU state
+ * @size:		Size in bytes of a slot (register).
+ * @core_note_type:	ELF note @n_type value used in core dumps.
+ * @get:		Function to fetch values.
+ * @active:		Function to report if regset is active, or %NULL.
+ *
+ * @name:               Note section name.
+ * @callback:           Function to edit thread core information, or %NULL.
+ *
+ * This data structure describes machine resource to be retrieved as
+ * process core dump. Each member of this structure characterizes the
+ * resource and the operations necessary in core dump process.
+ *
+ * @get provides a means of retrieving the corresponding resource;
+ * @active provides a means of checking if the resource exists; @size
+ * means a size of the machine resource in bytes; @core_note_type is a
+ * type of note information; @name is a note section name representing
+ * the owner originator that handles this kind of the machine
+ * resource; @callback is an extra operation to edit another note
+ * information of the same thread, required when the machine resource
+ * is collected.
+ */
+struct user_regset {
+	user_regset_get_fn		*get;
+	user_regset_active_fn		*active;
+	unsigned int 			size;
+	unsigned int 			core_note_type;
+	char                            *name;
+	user_regset_callback_fn         *callback;
+};
+
+/**
+ * struct user_regset_view - available regsets
+ * @name:	Identifier, e.g. UTS_MACHINE string.
+ * @regsets:	Array of @n regsets available in this view.
+ * @n:		Number of elements in @regsets.
+ * @e_machine:	ELF header @e_machine %EM_* value written in core dumps.
+ * @e_flags:	ELF header @e_flags value written in core dumps.
+ * @ei_osabi:	ELF header @e_ident[%EI_OSABI] value written in core dumps.
+ *
+ * A regset view is a collection of regsets (&struct user_regset,
+ * above).  This describes all the state of a thread that are
+ * collected as note information of process core dump.
+ */
+struct user_regset_view {
+	const char *name;
+	const struct user_regset *regsets;
+	unsigned int n;
+	uint32_t e_flags;
+	uint16_t e_machine;
+	uint8_t ei_osabi;
+};
+
+/**
+ * task_user_regset_view - Return the process's regset view.
+ *
+ * Return the &struct user_regset_view. By default, it returns
+ * &gcore_default_regset_view.
+ *
+ * This is defined as a weak symbol. If there's another
+ * task_user_regset_view at linking time, it is used instead, useful
+ * to support different kernel version or architecture.
+ */
+extern const struct user_regset_view *task_user_regset_view(void);
+extern void gcore_default_regsets_init(void);
+
+#ifdef X86
+#define REGSET_VIEW_NAME "i386"
+#define REGSET_VIEW_MACHINE EM_386
+#endif
+
+#ifdef X86_64
+#define REGSET_VIEW_NAME "x86_64"
+#define REGSET_VIEW_MACHINE EM_X86_64
+#endif
+
+#ifdef IA64
+#define REGSET_VIEW_NAME "ia64"
+#define REGSET_VIEW_MACHINE EM_IA_64
+#endif
+
+#ifdef ARM
+#define REGSET_VIEW_NAME "arm"
+#define REGSET_VIEW_MACHINE EM_ARM
+#endif
+
+#ifdef ARM64
+#define REGSET_VIEW_NAME "aarch64"
+#define REGSET_VIEW_MACHINE EM_AARCH64
+#endif
+
+#ifdef MIPS
+#define REGSET_VIEW_NAME "mips"
+#define REGSET_VIEW_MACHINE EM_MIPS
+#endif
+
+#ifdef PPC64
+#define REGSET_VIEW_NAME "ppc64"
+#define REGSET_VIEW_MACHINE EM_PPC64
+#endif
+
+extern int gcore_arch_get_fp_valid(struct task_context *tc);
+
+/*
+ * gcore_dumpfilter.c
+ */
+#define GCORE_DUMPFILTER_ANON_PRIVATE    (0x1)
+#define GCORE_DUMPFILTER_ANON_SHARED     (0x2)
+#define GCORE_DUMPFILTER_MAPPED_PRIVATE  (0x4)
+#define GCORE_DUMPFILTER_MAPPED_SHARED   (0x8)
+#define GCORE_DUMPFILTER_ELF_HEADERS     (0x10)
+#define GCORE_DUMPFILTER_HUGETLB_PRIVATE (0x20)
+#define GCORE_DUMPFILTER_HUGETLB_SHARED  (0x40)
+#define GCORE_DUMPFILTER_DONTDUMP        (0x80)
+
+#define GCORE_DUMPFILTER_MAX_LEVEL (GCORE_DUMPFILTER_ANON_PRIVATE	\
+				    |GCORE_DUMPFILTER_ANON_SHARED	\
+				    |GCORE_DUMPFILTER_MAPPED_PRIVATE	\
+				    |GCORE_DUMPFILTER_MAPPED_SHARED	\
+				    |GCORE_DUMPFILTER_ELF_HEADERS	\
+				    |GCORE_DUMPFILTER_HUGETLB_PRIVATE	\
+				    |GCORE_DUMPFILTER_HUGETLB_SHARED	\
+				    |GCORE_DUMPFILTER_DONTDUMP)
+
+#define GCORE_DUMPFILTER_DEFAULT (GCORE_DUMPFILTER_ANON_PRIVATE		\
+				  | GCORE_DUMPFILTER_ANON_SHARED	\
+				  | GCORE_DUMPFILTER_HUGETLB_PRIVATE)
+
+extern int gcore_dumpfilter_set(ulong filter);
+extern void gcore_dumpfilter_set_default(void);
+extern ulong gcore_dumpfilter_get(void);
+extern ulong gcore_dumpfilter_vma_dump_size(ulong vma);
+
+/*
+ * gcore_verbose.c
+ */
+#define VERBOSE_PROGRESS  0x1
+#define VERBOSE_NONQUIET  0x2
+#define VERBOSE_PAGEFAULT 0x4
+#define VERBOSE_DEFAULT_LEVEL VERBOSE_PAGEFAULT
+#define VERBOSE_MAX_LEVEL (VERBOSE_PROGRESS + VERBOSE_NONQUIET + \
+			   VERBOSE_PAGEFAULT)
+
+#define VERBOSE_DEFAULT_ERROR_HANDLE (FAULT_ON_ERROR | QUIET)
+
+/*
+ * Verbose flag is set each time gcore is executed. The same verbose
+ * flag value is used for all the tasks given together in the command
+ * line.
+ */
+extern void gcore_verbose_set_default(void);
+
+/**
+ * gcore_verbose_set() - set verbose level
+ *
+ * @level verbose level intended to be assigend: might be minus and
+ *        larger than VERBOSE_DEFAULT_LEVEL.
+ *
+ * If @level is a minus value or strictly larger than VERBOSE_MAX_LEVEL,
+ * return FALSE. Otherwise, update a global date, gvd, to @level, and returns
+ * TRUE.
+ */
+extern int gcore_verbose_set(ulong level);
+
+/**
+ * gcore_verbose_get() - get verbose level
+ *
+ * Return the current verbose level contained in the global data.
+ */
+extern ulong gcore_verbose_get(void);
+
+/**
+ * gcore_verbose_error_handle() - get error handle
+ *
+ * Return the current error_handle contained in the global data.
+ */
+extern ulong gcore_verbose_error_handle(void);
+
+/*
+ * Helper printing functions for respective verbose flags
+ */
+
+/**
+ * verbosef() - print verbose information if flag is set currently.
+ *
+ * @flag   verbose flag that is currently concerned about.
+ * @format printf style format that is printed into standard output.
+ *
+ * Always returns FALSE.
+ */
+#define verbosef(vflag, eflag, ...)					\
+	({								\
+		if (gcore_verbose_get() & (vflag)) {			\
+			(void) error((eflag), __VA_ARGS__);		\
+		}							\
+		FALSE;							\
+	})
+
+/**
+ * progressf() - print progress verbose information
+ *
+ * @format printf style format that is printed into standard output.
+ *
+ * Print progress verbose informaiton if VERBOSE_PROGRESS is set currently.
+ */
+#define progressf(...) verbosef(VERBOSE_PROGRESS, INFO, __VA_ARGS__)
+
+/**
+ * pagefaultf() - print page fault verbose information
+ *
+ * @format printf style format that is printed into standard output.
+ *
+ * print pagefault verbose informaiton if VERBOSE_PAGEFAULT is set currently.
+ */
+#define pagefaultf(...) verbosef(VERBOSE_PAGEFAULT, WARNING, __VA_ARGS__)
+
+/*
+ * gcore_x86.c
+ */
+extern struct gcore_x86_table *gxt;
+
+extern void gcore_x86_table_init(void);
+
+#ifdef X86_64
+struct user_regs_struct {
+	unsigned long	r15;
+	unsigned long	r14;
+	unsigned long	r13;
+	unsigned long	r12;
+	unsigned long	bp;
+	unsigned long	bx;
+	unsigned long	r11;
+	unsigned long	r10;
+	unsigned long	r9;
+	unsigned long	r8;
+	unsigned long	ax;
+	unsigned long	cx;
+	unsigned long	dx;
+	unsigned long	si;
+	unsigned long	di;
+	unsigned long	orig_ax;
+	unsigned long	ip;
+	unsigned long	cs;
+	unsigned long	flags;
+	unsigned long	sp;
+	unsigned long	ss;
+	unsigned long	fs_base;
+	unsigned long	gs_base;
+	unsigned long	ds;
+	unsigned long	es;
+	unsigned long	fs;
+	unsigned long	gs;
+};
+
+struct user_regs_struct32 {
+	uint32_t ebx, ecx, edx, esi, edi, ebp, eax;
+	unsigned short ds, __ds, es, __es;
+	unsigned short fs, __fs, gs, __gs;
+	uint32_t orig_eax, eip;
+	unsigned short cs, __cs;
+	uint32_t eflags, esp;
+	unsigned short ss, __ss;
+};
+#endif
+
+#ifdef X86
+struct user_regs_struct {
+	unsigned long	bx;
+	unsigned long	cx;
+	unsigned long	dx;
+	unsigned long	si;
+	unsigned long	di;
+	unsigned long	bp;
+	unsigned long	ax;
+	unsigned long	ds;
+	unsigned long	es;
+	unsigned long	fs;
+	unsigned long	gs;
+	unsigned long	orig_ax;
+	unsigned long	ip;
+	unsigned long	cs;
+	unsigned long	flags;
+	unsigned long	sp;
+	unsigned long	ss;
+};
+#endif
+
+#ifdef ARM
+struct user_fp {
+	struct fp_reg {
+		unsigned int sign1:1;
+		unsigned int unused:15;
+		unsigned int sign2:1;
+		unsigned int exponent:14;
+		unsigned int j:1;
+		unsigned int mantissa1:31;
+		unsigned int mantissa0:32;
+	} fpregs[8];
+	unsigned int fpsr:32;
+	unsigned int fpcr:32;
+	unsigned char ftype[8];
+	unsigned int init_flag;
+};
+
+struct user_vfp {
+	unsigned long long fpregs[32];
+	unsigned long fpscr;
+};
+
+struct user_regs_struct{
+	unsigned long r0;
+	unsigned long r1;
+	unsigned long r2;
+	unsigned long r3;
+	unsigned long r4;
+	unsigned long r5;
+	unsigned long r6;
+	unsigned long r7;
+	unsigned long r8;
+	unsigned long r9;
+	unsigned long r10;
+	unsigned long fp;
+	unsigned long ip;
+	unsigned long sp;
+	unsigned long lr;
+	unsigned long pc;
+	unsigned long cpsr;
+	unsigned long ORIG_r0;
+};
+
+#define ARM_VFPREGS_SIZE ( 32 * 8 /*fpregs*/ + 4 /*fpscr*/ )
+#endif
+
+#ifdef ARM64
+
+typedef unsigned int __u32;
+/*
+ * User structures for general purpose, floating point and debug registers.
+ */
+struct user_pt_regs {
+        __u64           regs[31];
+        __u64           sp;
+        __u64           pc;
+        __u64           pstate;
+};
+
+struct user_fpsimd_state {
+        __uint128_t     vregs[32];
+        __u32           fpsr;
+        __u32           fpcr;
+};
+
+struct user_hwdebug_state {
+        __u32           dbg_info;
+        __u32           pad;
+        struct {
+                __u64   addr;
+                __u32   ctrl;
+                __u32   pad;
+        }               dbg_regs[16];
+};
+
+/* Type for a general-purpose register.  */
+typedef unsigned long elf_greg_t;
+
+/* And the whole bunch of them.  We could have used `struct
+   pt_regs' directly in the typedef, but tradition says that
+   the register set is an array, which does have some peculiar
+   semantics, so leave it that way.  */
+#define ELF_NGREG (sizeof (struct user_pt_regs) / sizeof(elf_greg_t))
+typedef elf_greg_t elf_gregset_t[ELF_NGREG];
+
+/* Register set for the floating-point registers.  */
+typedef struct user_fpsimd_state elf_fpregset_t;
+
+#ifdef GCORE_ARCH_COMPAT
+/* AArch32 registers. */
+struct user_regs_struct32{
+	uint32_t r0;
+	uint32_t r1;
+	uint32_t r2;
+	uint32_t r3;
+	uint32_t r4;
+	uint32_t r5;
+	uint32_t r6;
+	uint32_t r7;
+	uint32_t r8;
+	uint32_t r9;
+	uint32_t r10;
+	uint32_t fp;
+	uint32_t ip;
+	uint32_t sp;
+	uint32_t lr;
+	uint32_t pc;
+	uint32_t cpsr;
+	uint32_t ORIG_r0;
+};
+#endif /* GCORE_ARCH_COMPAT */
+#endif
+
+#ifdef MIPS
+struct user_regs_struct {
+	unsigned long gregs[45];
+};
+#endif
+
+#ifdef PPC64
+/* taken from asm/ptrace.h */
+struct user_regs_struct {
+	unsigned long gpr[32];
+	unsigned long nip;
+	unsigned long msr;
+	unsigned long orig_gpr3;	/* Used for restarting system calls */
+	unsigned long ctr;
+	unsigned long link;
+	unsigned long xer;
+	unsigned long ccr;
+#ifdef __powerpc64__
+	unsigned long softe;		/* Soft enabled/disabled */
+#else
+	unsigned long mq;		/* 601 only (not used at present) */
+			/* Used on APUS to hold IPL value. */
+#endif
+	unsigned long trap;		/* Reason for being here */
+	/* N.B. for critical exceptions on 4xx, the dar and dsisr
+	   fields are overloaded to hold srr0 and srr1. */
+	unsigned long dar;		/* Fault registers */
+	unsigned long dsisr;		/* on 4xx/Book-E used for ESR */
+	unsigned long result;		/* Result of a system call */
+};
+#endif
+
+#if defined(X86) || defined(X86_64) || defined(ARM) || defined(MIPS)
+typedef ulong elf_greg_t;
+#define ELF_NGREG (sizeof(struct user_regs_struct) / sizeof(elf_greg_t))
+typedef elf_greg_t elf_gregset_t[ELF_NGREG];
+#endif
+
+#if defined(X86) || defined(ARM) || defined(MIPS)
+#define PAGE_SIZE 4096
+#endif
+#if defined(ARM64) || defined(PPC64)
+#define PAGE_SIZE PAGESIZE()
+#endif
+
+extern int gcore_is_arch_32bit_emulation(struct task_context *tc);
+extern ulong gcore_arch_get_gate_vma(void);
+extern char *gcore_arch_vma_name(ulong vma);
+extern int gcore_arch_vsyscall_has_vm_alwaysdump_flag(void);
+
+/*
+ * gcore_coredump_table.c
+ */
+extern void gcore_coredump_table_init(void);
+
+/*
+ * gcore_coredump.c
+ */
+extern void gcore_coredump(void);
+
+/*
+ * gcore_global_data.c
+ */
+extern struct gcore_one_session_data *gcore;
+extern struct gcore_coredump_table *ggt;
+extern struct gcore_offset_table gcore_offset_table;
+extern struct gcore_size_table gcore_size_table;
+extern struct gcore_machdep_table *gcore_machdep;
+
+/*
+ * Misc
+ */
+enum pid_type
+{
+        PIDTYPE_PID,
+        PIDTYPE_PGID,
+        PIDTYPE_SID,
+        PIDTYPE_MAX
+};
+
+struct elf_siginfo
+{
+        int     si_signo;                       /* signal number */
+	int     si_code;                        /* extra code */
+        int     si_errno;                       /* errno */
+};
+
+/* Parameters used to convert the timespec values: */
+#define NSEC_PER_USEC   1000L
+#define NSEC_PER_SEC    1000000000L
+
+/* The clock frequency of the i8253/i8254 PIT */
+#define PIT_TICK_RATE 1193182ul
+
+/* Assume we use the PIT time source for the clock tick */
+#define CLOCK_TICK_RATE         PIT_TICK_RATE
+
+/* LATCH is used in the interval timer and ftape setup. */
+#define LATCH  ((CLOCK_TICK_RATE + HZ/2) / HZ)  /* For divider */
+
+/* Suppose we want to devide two numbers NOM and DEN: NOM/DEN, then we can
+ * improve accuracy by shifting LSH bits, hence calculating:
+ *     (NOM << LSH) / DEN
+ * This however means trouble for large NOM, because (NOM << LSH) may no
+ * longer fit in 32 bits. The following way of calculating this gives us
+ * some slack, under the following conditions:
+ *   - (NOM / DEN) fits in (32 - LSH) bits.
+ *   - (NOM % DEN) fits in (32 - LSH) bits.
+ */
+#define SH_DIV(NOM,DEN,LSH) (   (((NOM) / (DEN)) << (LSH))              \
+				+ ((((NOM) % (DEN)) << (LSH)) + (DEN) / 2) / (DEN))
+
+/* HZ is the requested value. ACTHZ is actual HZ ("<< 8" is for accuracy) */
+#define ACTHZ (SH_DIV (CLOCK_TICK_RATE, LATCH, 8))
+
+/* TICK_NSEC is the time between ticks in nsec assuming real ACTHZ */
+#define TICK_NSEC (SH_DIV (1000000UL * 1000, ACTHZ, 8))
+
+#define cputime_add(__a, __b)           ((__a) +  (__b))
+#define cputime_sub(__a, __b)           ((__a) -  (__b))
+
+typedef unsigned long cputime_t;
+
+#define cputime_zero                    (0UL)
+
+struct task_cputime {
+        cputime_t utime;
+        cputime_t stime;
+        unsigned long long sum_exec_runtime;
+};
+
+#define INIT_CPUTIME						\
+        (struct task_cputime) {                                 \
+                .utime = cputime_zero,                          \
+			.stime = cputime_zero,                          \
+			.sum_exec_runtime = 0,                          \
+			}
+
+static inline uint64_t div_u64_rem(uint64_t dividend, uint32_t divisor,
+				   uint32_t *remainder)
+{
+        *remainder = dividend % divisor;
+        return dividend / divisor;
+}
+
+static inline void
+jiffies_to_timeval(const cputime_t jiffies, struct timeval *value)
+{
+        /*
+         * Convert jiffies to nanoseconds and separate with
+         * one divide.
+         */
+        uint32_t rem;
+
+        value->tv_sec = div_u64_rem((uint64_t)jiffies * TICK_NSEC,
+                                    NSEC_PER_SEC, &rem);
+        value->tv_usec = rem / NSEC_PER_USEC;
+}
+
+static inline void
+cputime_to_timeval(const cputime_t cputime, struct timeval *value)
+{
+	jiffies_to_timeval(cputime, value);
+}
+
+#ifdef GCORE_ARCH_COMPAT
+static inline void
+cputime_to_compat_timeval(const cputime_t cputime,
+			  struct compat_timeval *value)
+{
+	struct timeval tv;
+	cputime_to_timeval(cputime, &tv);
+	value->tv_sec = tv.tv_sec;
+	value->tv_usec = tv.tv_usec;
+}
+#endif
+
+struct elf_prstatus
+{
+	struct elf_siginfo pr_info;	/* Info associated with signal */
+	short	pr_cursig;		/* Current signal */
+	unsigned long pr_sigpend;	/* Set of pending signals */
+	unsigned long pr_sighold;	/* Set of held signals */
+	int	pr_pid;
+	int	pr_ppid;
+	int	pr_pgrp;
+	int	pr_sid;
+	struct timeval pr_utime;	/* User time */
+	struct timeval pr_stime;	/* System time */
+	struct timeval pr_cutime;	/* Cumulative user time */
+	struct timeval pr_cstime;	/* Cumulative system time */
+	elf_gregset_t pr_reg;	/* GP registers */
+	int pr_fpvalid;		/* True if math co-processor being used.  */
+};
+
+#if defined(X86) || defined(X86_64) || defined(ARM) || defined(MIPS)
+typedef unsigned short __kernel_old_uid_t;
+typedef unsigned short __kernel_old_gid_t;
+#endif
+
+#if defined(X86_64) || defined(ARM64) || defined(PPC64)
+typedef unsigned int __kernel_uid_t;
+typedef unsigned int __kernel_gid_t;
+#endif
+
+#ifdef ARM64
+#ifndef __kernel_old_uid_t
+typedef __kernel_uid_t  __kernel_old_uid_t;
+typedef __kernel_gid_t  __kernel_old_gid_t;
+#endif
+#endif
+
+typedef __kernel_old_uid_t      old_uid_t;
+typedef __kernel_old_gid_t      old_gid_t;
+
+#if defined(X86) || defined(ARM) || defined(MIPS)
+typedef unsigned short __kernel_uid_t;
+typedef unsigned short __kernel_gid_t;
+#endif
+
+#define overflowuid (symbol_exists("overflowuid"))
+#define overflowgid (symbol_exists("overflowgid"))
+
+#define high2lowuid(uid) ((uid) & ~0xFFFF ? (old_uid_t)overflowuid : (old_uid_t)(uid))
+#define high2lowgid(gid) ((gid) & ~0xFFFF ? (old_gid_t)overflowgid : (old_gid_t)(gid))
+
+#define __convert_uid(size, uid) \
+        (size >= sizeof(uid) ? (uid) : high2lowuid(uid))
+#define __convert_gid(size, gid) \
+        (size >= sizeof(gid) ? (gid) : high2lowgid(gid))
+
+#define SET_UID(var, uid) do { (var) = __convert_uid(sizeof(var), (uid)); } while (0)
+#define SET_GID(var, gid) do { (var) = __convert_gid(sizeof(var), (gid)); } while (0)
+
+#define MAX_USER_RT_PRIO        100
+#define MAX_RT_PRIO             MAX_USER_RT_PRIO
+
+#define PRIO_TO_NICE(prio)      ((prio) - MAX_RT_PRIO - 20)
+#define TASK_NICE(p)            PRIO_TO_NICE((p)->static_prio)
+
+static inline ulong ffz(ulong word)
+{
+        int num = 0;
+
+#if defined(X86_64) || defined(IA64)
+        if ((word & 0xffffffff) == 0) {
+                num += 32;
+                word >>= 32;
+        }
+#endif
+        if ((word & 0xffff) == 0) {
+                num += 16;
+                word >>= 16;
+        }
+        if ((word & 0xff) == 0) {
+                num += 8;
+                word >>= 8;
+        }
+        if ((word & 0xf) == 0) {
+                num += 4;
+                word >>= 4;
+        }
+        if ((word & 0x3) == 0) {
+                num += 2;
+                word >>= 2;
+        }
+        if ((word & 0x1) == 0)
+                num += 1;
+        return num;
+}
+
+#define ELF_PRARGSZ     (80)    /* Number of chars for args */
+
+struct elf_prpsinfo
+{
+        char    pr_state;       /* numeric process state */
+        char    pr_sname;       /* char for pr_state */
+        char    pr_zomb;        /* zombie */
+        char    pr_nice;        /* nice val */
+        unsigned long pr_flag;  /* flags */
+        __kernel_uid_t  pr_uid;
+        __kernel_gid_t  pr_gid;
+        pid_t   pr_pid, pr_ppid, pr_pgrp, pr_sid;
+        /* Lots missing */
+        char    pr_fname[16];   /* filename of executable */
+        char    pr_psargs[ELF_PRARGSZ]; /* initial part of arg list */
+};
+
+#ifdef GCORE_ARCH_COMPAT
+
+struct compat_elf_siginfo
+{
+	compat_int_t			si_signo;
+	compat_int_t			si_code;
+	compat_int_t			si_errno;
+};
+
+struct compat_elf_prstatus
+{
+	struct compat_elf_siginfo	pr_info;
+	short				pr_cursig;
+	compat_ulong_t			pr_sigpend;
+	compat_ulong_t			pr_sighold;
+	compat_pid_t			pr_pid;
+	compat_pid_t			pr_ppid;
+	compat_pid_t			pr_pgrp;
+	compat_pid_t			pr_sid;
+	struct compat_timeval		pr_utime;
+	struct compat_timeval		pr_stime;
+	struct compat_timeval		pr_cutime;
+	struct compat_timeval		pr_cstime;
+	compat_elf_gregset_t		pr_reg;
+	compat_int_t			pr_fpvalid;
+};
+
+struct compat_elf_prpsinfo
+{
+	char				pr_state;
+	char				pr_sname;
+	char				pr_zomb;
+	char				pr_nice;
+	compat_ulong_t			pr_flag;
+	__compat_uid_t			pr_uid;
+	__compat_gid_t			pr_gid;
+	compat_pid_t			pr_pid, pr_ppid, pr_pgrp, pr_sid;
+	char				pr_fname[16];
+	char				pr_psargs[ELF_PRARGSZ];
+};
+
+#endif /* GCORE_ARCH_COMPAT */
+
+#define TASK_COMM_LEN 16
+
+#define	CORENAME_MAX_SIZE 128
+
+struct thread_group_list {
+	struct thread_group_list *next;
+	ulong task;
+};
+
+struct memelfnote
+{
+	const char *name;
+	int type;
+	unsigned int datasz;
+	void *data;
+};
+
+struct elf_note_info {
+	void (*fill_prstatus_note)(struct elf_note_info *info,
+				   struct task_context *tc,
+				   struct memelfnote *memnote);
+	void (*fill_psinfo_note)(struct elf_note_info *info,
+				 struct task_context *tc,
+				 struct memelfnote *memnote);
+	void (*fill_auxv_note)(struct elf_note_info *info,
+			       struct task_context *tc,
+			       struct memelfnote *memnote);
+	int (*fill_files_note)(struct elf_note_info *info,
+			       struct task_context *tc,
+			       struct memelfnote *memnote);
+	size_t size;
+	int thread_notes;
+};
+
+/*
+ * vm_flags in vm_area_struct, see mm_types.h.
+ */
+#define VM_READ		0x00000001	/* currently active flags */
+#define VM_WRITE	0x00000002
+#define VM_EXEC		0x00000004
+#define VM_SHARED	0x00000008
+#define VM_IO           0x00004000      /* Memory mapped I/O or similar */
+#define VM_RESERVED     0x00080000      /* Count as reserved_vm like IO */
+#define VM_HUGETLB      0x00400000      /* Huge TLB Page VM */
+#define VM_DONTDUMP	0x04000000	/* Do not include in the core dump */
+#define VM_ALWAYSDUMP   (gcore_machdep->vm_alwaysdump)
+                                        /* Always include in core dumps */
+
+extern ulong first_vma(ulong mmap, ulong gate_vma);
+extern ulong next_vma(ulong this_vma, ulong gate_vma);
+
+#define FOR_EACH_VMA_OBJECT(vma, index, mmap, gate_vma)			\
+	for (index = 0, vma = first_vma(mmap, gate_vma); vma;		\
+	     ++index, vma = next_vma(vma, gate_vma))
+
+extern struct task_context *
+next_task_context(ulong tgid, struct task_context *tc);
+
+static inline struct task_context *first_task_context(ulong tgid)
+{
+	return next_task_context(tgid, FIRST_CONTEXT());
+}
+
+#define FOR_EACH_TASK_IN_THREAD_GROUP(tgid, tc)				\
+	for (tc = first_task_context(tgid); tc;				\
+	     tc = next_task_context(tgid, tc))
+
+extern int _init(void);
+extern int _fini(void);
+extern char *help_gcore[];
+extern void cmd_gcore(void);
+
+struct gcore_coredump_table {
+
+	unsigned int (*get_inode_i_nlink)(ulong file);
+
+	pid_t (*task_pid)(ulong task);
+	pid_t (*task_pgrp)(ulong task);
+	pid_t (*task_session)(ulong task);
+
+	void (*thread_group_cputime)(ulong task,
+				     struct task_cputime *cputime);
+
+	__kernel_uid_t (*task_uid)(ulong task);
+	__kernel_gid_t (*task_gid)(ulong task);
+};
+
+struct gcore_offset_table
+{
+	long cpuinfo_x86_hard_math;
+	long cpuinfo_x86_x86_capability;
+	long cred_gid;
+	long cred_uid;
+	long desc_struct_base0;
+	long desc_struct_base1;
+	long desc_struct_base2;
+	long fpu_state;
+	long inode_i_nlink;
+	long nsproxy_pid_ns;
+	long mm_context_t_vdso;
+	long mm_struct_arg_start;
+	long mm_struct_arg_end;
+	long mm_struct_map_count;
+	long mm_struct_reserved_vm;
+	long mm_struct_saved_auxv;
+	long mm_struct_saved_files;
+	long mm_struct_context;
+	long pid_level;
+	long pid_namespace_level;
+	long pt_regs_ax;
+	long pt_regs_bp;
+	long pt_regs_bx;
+	long pt_regs_cs;
+	long pt_regs_cx;
+	long pt_regs_di;
+	long pt_regs_ds;
+	long pt_regs_dx;
+	long pt_regs_es;
+	long pt_regs_flags;
+	long pt_regs_fs;
+	long pt_regs_gs;
+	long pt_regs_ip;
+	long pt_regs_orig_ax;
+	long pt_regs_si;
+	long pt_regs_sp;
+	long pt_regs_ss;
+	long pt_regs_xfs;
+	long pt_regs_xgs;
+	long sched_entity_sum_exec_runtime;
+	long signal_struct_cutime;
+	long signal_struct_pgrp;
+	long signal_struct_pids;
+	long signal_struct_session;
+	long signal_struct_stime;
+	long signal_struct_sum_sched_runtime;
+	long signal_struct_utime;
+	long task_struct_cred;
+	long task_struct_gid;
+	long task_struct_group_leader;
+	long task_struct_real_cred;
+	long task_struct_real_parent;
+	long task_struct_se;
+	long task_struct_static_prio;
+	long task_struct_uid;
+	long task_struct_used_math;
+	long task_struct_thread_pid;
+	long thread_info_status;
+	long thread_info_fpstate;
+	long thread_info_vfpstate;
+	long thread_struct_ds;
+	long thread_struct_es;
+	long thread_struct_fs;
+	long thread_struct_fsindex;
+	long thread_struct_fpu;
+	long thread_struct_gs;
+	long thread_struct_gsindex;
+	long thread_struct_i387;
+	long thread_struct_sp0;
+	long thread_struct_tls_array;
+	long thread_struct_usersp;
+	long thread_struct_xstate;
+	long thread_struct_io_bitmap_max;
+	long thread_struct_io_bitmap_ptr;
+	long thread_struct_fpsimd_state;
+	long thread_struct_tp_value;
+	long user_regset_n;
+	long vfp_state_hard;
+	long vfp_hard_struct_fpregs;
+	long vfp_hard_struct_fpscr;
+	long vm_area_struct_anon_vma;
+	long vm_area_struct_vm_ops;
+	long vm_area_struct_vm_private_data;
+	long vm_operations_struct_name;
+	long vm_special_mapping_name;
+	long x8664_pda_oldrsp;
+};
+
+struct gcore_size_table
+{
+	long mm_context_t;
+	long mm_struct_saved_auxv;
+	long mm_struct_saved_files;
+	long thread_struct_ds;
+	long thread_struct_es;
+	long thread_struct_fs;
+	long thread_struct_fsindex;
+	long thread_struct_gs;
+	long thread_struct_gsindex;
+	long thread_struct_tls_array;
+	long vfp_hard_struct_fpregs;
+	long vfp_hard_struct_fpscr;
+	long vm_area_struct_anon_vma;
+	long thread_xstate;
+	long i387_union;
+};
+
+#define GCORE_OFFSET(X) (OFFSET_verify(gcore_offset_table.X, (char *)__FUNCTION__, __FILE__, __LINE__, #X))
+#define GCORE_SIZE(X) (SIZE_verify(gcore_size_table.X, (char *)__FUNCTION__, __FILE__, __LINE__, #X))
+#define GCORE_VALID_MEMBER(X) (gcore_offset_table.X >= 0)
+#define GCORE_ASSIGN_OFFSET(X) (gcore_offset_table.X)
+#define GCORE_MEMBER_OFFSET_INIT(X, Y, Z) (GCORE_ASSIGN_OFFSET(X) = MEMBER_OFFSET(Y, Z))
+#define GCORE_ASSIGN_SIZE(X) (gcore_size_table.X)
+#define GCORE_SIZE_INIT(X, Y, Z) (GCORE_ASSIGN_SIZE(X) = MEMBER_SIZE(Y, Z))
+#define GCORE_MEMBER_SIZE_INIT(X, Y, Z) (GCORE_ASSIGN_SIZE(X) = MEMBER_SIZE(Y, Z))
+#define GCORE_STRUCT_SIZE_INIT(X, Y) (GCORE_ASSIGN_SIZE(X) = STRUCT_SIZE(Y))
+
+#define GCORE_INVALID_MEMBER(X) (gcore_offset_table.X == INVALID_OFFSET)
+
+#define GCORE_ANON_MEMBER_OFFSET_REQUEST ((struct datatype_member *)(-2))
+#define GCORE_ANON_MEMBER_OFFSET(X,Y)    datatype_info((X), (Y), GCORE_ANON_MEMBER_OFFSET_REQUEST)
+#define GCORE_ANON_MEMBER_OFFSET_INIT(X, Y, Z) (GCORE_ASSIGN_OFFSET(X) = ANON_MEMBER_OFFSET(Y, Z))
+
+extern struct gcore_offset_table gcore_offset_table;
+extern struct gcore_size_table gcore_size_table;
+
+struct gcore_machdep_table
+{
+	ulong vm_alwaysdump;
+};
+
+/*
+ * gcore flags
+ */
+#define GCF_SUCCESS     0x1
+#define GCF_UNDER_COREDUMP 0x2
+
+/**
+ * Abstract Elf64 and Elf32 structures and operations on them in order
+ * to support tasks in 32-bit mode on 64-bit machine. The current
+ * target is IA32e compatibility mode on X86_64 only.
+ *
+ * Actual implementations for X86 and X86_64 is in gcore_elf_struct.c.
+ */
+
+struct gcore_elf_struct;
+
+struct gcore_elf_operations
+{
+	void (*fill_elf_header)(struct gcore_elf_struct *this,
+				uint16_t e_phnum, uint16_t e_machine,
+				uint32_t e_flags, uint8_t ei_osabi);
+	void (*fill_section_header)(struct gcore_elf_struct *this, int phnum);
+	void (*fill_program_header)(struct gcore_elf_struct *this,
+				    uint32_t p_type, uint32_t p_flags,
+				    uint64_t p_offset, uint64_t p_vaddr,
+				    uint64_t p_filesz, uint64_t p_memsz,
+				    uint64_t p_align);
+	void (*fill_note_header)(struct gcore_elf_struct *this,
+				 uint32_t n_namesz, uint32_t n_descsz,
+				 uint32_t n_type);
+
+	/**
+	 * A set of helper functions to perform write operation for
+	 * respective ELF data structures.
+	 *
+	 *  @fd file descripter for a generated core dump file.
+	 *
+	 * - Return TRUE if write operation is successfully
+	 *   done. Otherwise, return FALSE.
+	 *
+	 * - No exception is raised.
+	 */
+	int (*write_elf_header)(struct gcore_elf_struct *this, FILE *fp);
+	int (*write_section_header)(struct gcore_elf_struct *this, FILE *fp);
+	int (*write_program_header)(struct gcore_elf_struct *this, FILE *fp);
+	int (*write_note_header)(struct gcore_elf_struct *this, FILE *fp,
+				 off_t *offset);
+
+	uint64_t (*get_e_phoff)(struct gcore_elf_struct *this);
+	uint64_t (*get_e_shoff)(struct gcore_elf_struct *this);
+
+	/**
+	 * Get fields of section header.
+	 */
+	uint32_t (*get_sh_info)(struct gcore_elf_struct *this);
+
+	size_t (*get_note_header_size)(struct gcore_elf_struct *this);
+
+	off_t (*calc_segment_offset)(struct gcore_elf_struct *this);
+};
+
+struct gcore_elf_struct
+{
+	struct gcore_elf_operations *ops;
+};
+
+extern const struct gcore_elf_operations *gcore_elf64_get_operations(void);
+extern const struct gcore_elf_operations *gcore_elf32_get_operations(void);
+
+extern void gcore_elf_init(struct gcore_one_session_data *gcore);
+
+/*
+ * Data used during one session; one session means a period of core
+ * dump processing for a given task. For example, suppose:
+ *
+ *     crash> gcore task1 task2
+ *
+ * Then, there're two sessions: one for task1 and the other for
+ * task2. Session for task1 is not used for task2; all fields of which
+ * is initialized at the beginning of dump processing for task2.
+ */
+struct gcore_one_session_data
+{
+	ulong flags;
+	FILE *fp;
+	ulong orig_task;
+	char corename[CORENAME_MAX_SIZE + 1];
+	struct gcore_elf_struct *elf;
+};
+
+static inline void gcore_arch_table_init(void)
+{
+#if defined (X86_64) || defined (X86)
+	gcore_x86_table_init();
+#endif
+}
+
+#ifdef X86_64
+extern void gcore_x86_64_regsets_init(void);
+extern void gcore_x86_32_regsets_init(void);
+#define gcore_arch_regsets_init gcore_x86_64_regsets_init
+#endif
+
+#ifdef X86
+extern void gcore_x86_32_regsets_init(void);
+#define gcore_arch_regsets_init gcore_x86_32_regsets_init
+#endif
+
+#ifndef gcore_arch_regsets_init
+extern void gcore_default_regsets_init(void);
+#define gcore_arch_regsets_init gcore_default_regsets_init
+#endif
+
+#define VDSO_HIGH_BASE 0xffffe000U
+
+#endif /* GCORE_DEFS_H_ */

--- a/extensions/libgcore/gcore_dumpfilter.c
+++ b/extensions/libgcore/gcore_dumpfilter.c
@@ -1,0 +1,238 @@
+/* gcore_dumpfilter.c -- core analysis suite
+ *
+ * Copyright (C) 2010, 2011 FUJITSU LIMITED
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+#include <defs.h>
+#include <gcore_defs.h>
+#include <elf.h>
+
+static ulong dumpfilter = GCORE_DUMPFILTER_DEFAULT;
+
+static int special_mapping_name(ulong vma)
+{
+	ulong vm_private_data, name_p;
+
+	readmem(vma + GCORE_OFFSET(vm_area_struct_vm_private_data),
+		KVADDR,
+		&vm_private_data,
+		sizeof(vm_private_data),
+		"always_dump_vma: vma->vm_private_data",
+		gcore_verbose_error_handle());
+
+	readmem(vm_private_data +
+		GCORE_OFFSET(vm_special_mapping_name),
+		KVADDR,
+		&name_p,
+		sizeof(name_p),
+		"always_dump_vma: ((struct vm_special_mapping *)vma->vm_private_data)->name",
+		gcore_verbose_error_handle());
+
+	return name_p ? TRUE : FALSE;
+}
+
+static int always_dump_vma(ulong vma)
+{
+	if (vma == gcore_arch_get_gate_vma())
+		return TRUE;
+
+	if (GCORE_VALID_MEMBER(vm_special_mapping_name)) {
+		ulong vm_ops, name;
+
+		readmem(vma + GCORE_OFFSET(vm_area_struct_vm_ops),
+			KVADDR,
+			&vm_ops,
+			sizeof(vm_ops),
+			"always_dump_vma: vma->vm_ops",
+			gcore_verbose_error_handle());
+
+		if (!vm_ops)
+			goto out;
+
+		readmem(vm_ops + GCORE_OFFSET(vm_operations_struct_name),
+			KVADDR,
+			&name,
+			sizeof(name),
+			"always_dump_vma: vma->vm_ops->name",
+			gcore_verbose_error_handle());
+
+		if (!name)
+			goto out;
+
+		if (name == symbol_value("special_mapping_name"))
+			return special_mapping_name(vma);
+	}
+out:
+
+	if (gcore_arch_vma_name(vma))
+		return TRUE;
+	return FALSE;
+}
+
+/**
+ * Set a given filter value to the current state
+ * @filter a filter value given from command line
+ *
+ * Precondition:
+ *
+ *   - Nothing.
+ *
+ * Postcondition:
+ *
+ *   - If @filter > GCORE_DUMPFILTER_MAX_LEVEL, then the Precondition remains.
+ *
+ *   - Otherwise, dumpfilter == @filter.
+ *
+ * Return Value:
+ *
+ *   - If @filter > GCORE_DUMPFILTER_MAX_LEVEL, return FALSE.
+ *   - Otherwise, return TRUE>
+ */
+int gcore_dumpfilter_set(ulong filter)
+{
+	if (filter > GCORE_DUMPFILTER_MAX_LEVEL)
+		return FALSE;
+
+	dumpfilter = filter;
+
+	return TRUE;
+}
+
+void gcore_dumpfilter_set_default(void)
+{
+	dumpfilter = GCORE_DUMPFILTER_DEFAULT;
+}
+
+ulong gcore_dumpfilter_get(void)
+{
+	return dumpfilter;
+}
+
+static inline int is_filtered(int bit)
+{
+	return !!(dumpfilter & bit);
+}
+
+ulong gcore_dumpfilter_vma_dump_size(ulong vma)
+{
+	char *vma_cache;
+	physaddr_t paddr;
+	ulong vm_start, vm_end, vm_flags, vm_file, vm_pgoff, anon_vma;
+
+	vma_cache = fill_vma_cache(vma);
+	vm_start = ULONG(vma_cache + OFFSET(vm_area_struct_vm_start));
+	vm_end = ULONG(vma_cache + OFFSET(vm_area_struct_vm_end));
+	vm_flags = ULONG(vma_cache + OFFSET(vm_area_struct_vm_flags));
+	vm_file = ULONG(vma_cache + OFFSET(vm_area_struct_vm_file));
+	vm_pgoff = ULONG(vma_cache + OFFSET(vm_area_struct_vm_pgoff));
+	anon_vma = ULONG(vma_cache + GCORE_OFFSET(vm_area_struct_anon_vma));
+
+        /* always dump the vdso and vsyscall sections */
+	if (always_dump_vma(vma))
+		goto whole;
+
+	if (!gcore_machdep->vm_alwaysdump && (vm_flags & VM_DONTDUMP) &&
+	    !is_filtered(GCORE_DUMPFILTER_DONTDUMP))
+		goto nothing;
+
+        /* Hugetlb memory check */
+	if (vm_flags & VM_HUGETLB) {
+		if ((vm_flags & VM_SHARED)
+		    ? is_filtered(GCORE_DUMPFILTER_HUGETLB_SHARED)
+		    : is_filtered(GCORE_DUMPFILTER_HUGETLB_PRIVATE))
+			goto whole;
+
+		/* Hugepage memory filtering was introduced at the
+		 * time where VM_NODUMP or VM_DONTDUMP flag was not
+		 * introduced yet, so there was still VM_RESERVED
+		 * flag. At that time, vmas with VM_HUGETLB flag
+		 * always had VM_RESERVED flag, too. This means that
+		 * if the vma had VM_HUGETLB flag and it was not
+		 * filtered by neither of two filtering types,
+		 * GCORE_DUMPFILTER_HUGETLB_{SHARED, PRIVATE}, then
+		 * the memory was always filtered by VM_RESEARVED
+		 * check below. However, after VM_NODUMP or
+		 * VM_DONTDUMP was introduced, VM_RESERVED flag was
+		 * removed and the check to see if VM_RESERVED flag
+		 * was set, was also removed. This goto nothing is
+		 * needed instead of checking the VM_RESERVED flag. */
+		goto nothing;
+	}
+
+        /* Do not dump I/O mapped devices */
+        if (vm_flags & VM_IO)
+		goto nothing;
+
+	/* Do not dump special mappings */
+	if (GCORE_VALID_MEMBER(mm_struct_reserved_vm)
+	    && (vm_flags & VM_RESERVED))
+		goto nothing;
+
+        /* By default, dump shared memory if mapped from an anonymous file. */
+        if (vm_flags & VM_SHARED) {
+
+		if (ggt->get_inode_i_nlink(vm_file)
+		    ? is_filtered(GCORE_DUMPFILTER_MAPPED_SHARED)
+		    : is_filtered(GCORE_DUMPFILTER_ANON_SHARED))
+			goto whole;
+
+		goto nothing;
+        }
+
+        /* Dump segments that have been written to.  */
+        if (anon_vma && is_filtered(GCORE_DUMPFILTER_ANON_PRIVATE))
+                goto whole;
+        if (!vm_file)
+		goto nothing;
+
+        if (is_filtered(GCORE_DUMPFILTER_MAPPED_PRIVATE))
+                goto whole;
+
+        /*
+         * If this looks like the beginning of a DSO or executable mapping,
+         * check for an ELF header.  If we find one, dump the first page to
+         * aid in determining what was mapped here.
+         */
+        if (is_filtered(GCORE_DUMPFILTER_ELF_HEADERS) &&
+            vm_pgoff == 0 && (vm_flags & VM_READ)) {
+		ulong header = vm_start;
+		uint32_t word = 0;
+                /*
+                 * Doing it this way gets the constant folded by GCC.
+                 */
+                union {
+                        uint32_t cmp;
+                        char elfmag[SELFMAG];
+                } magic;
+                magic.elfmag[EI_MAG0] = ELFMAG0;
+                magic.elfmag[EI_MAG1] = ELFMAG1;
+                magic.elfmag[EI_MAG2] = ELFMAG2;
+                magic.elfmag[EI_MAG3] = ELFMAG3;
+		if (uvtop(CURRENT_CONTEXT(), header, &paddr, FALSE)) {
+			readmem(paddr, PHYSADDR, &word, sizeof(magic.elfmag),
+				"read ELF page", gcore_verbose_error_handle());
+		} else {
+			pagefaultf("page fault at %lx\n", header);
+		}
+                if (word == magic.cmp)
+			goto pagesize;
+        }
+
+nothing:
+        return 0;
+
+whole:
+        return vm_end - vm_start;
+
+pagesize:
+	return PAGE_SIZE;
+}

--- a/extensions/libgcore/gcore_elf_struct.c
+++ b/extensions/libgcore/gcore_elf_struct.c
@@ -1,0 +1,423 @@
+/* gcore_elf_struct.c -- core analysis suite
+ *
+ * Copyright (C) 2011 FUJITSU LIMITED
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <defs.h>
+#include "gcore_defs.h"
+
+struct gcore_elf64_struct
+{
+	struct gcore_elf_struct super;
+	Elf64_Ehdr ehdr;
+	Elf64_Shdr shdr;
+	Elf64_Phdr phdr;
+	Elf64_Nhdr nhdr;
+};
+
+struct gcore_elf32_struct
+{
+	struct gcore_elf_struct super;
+	Elf32_Ehdr ehdr;
+	Elf32_Shdr shdr;
+	Elf32_Phdr phdr;
+	Elf32_Nhdr nhdr;
+};
+
+static void
+elf64_fill_elf_header(struct gcore_elf_struct *this, uint16_t e_phnum,
+		      uint16_t e_machine, uint32_t e_flags, uint8_t ei_osabi)
+{
+	Elf64_Ehdr *e = &((struct gcore_elf64_struct *)this)->ehdr;
+
+	BZERO(e, sizeof(*e));
+
+	BCOPY(ELFMAG, e->e_ident, SELFMAG);
+	e->e_ident[EI_CLASS] = ELFCLASS64;
+	e->e_ident[EI_DATA] = ELF_DATA;
+	e->e_ident[EI_VERSION] = EV_CURRENT;
+	e->e_ident[EI_OSABI] = ei_osabi;
+	e->e_ehsize = sizeof(Elf64_Ehdr);
+	e->e_phentsize = sizeof(Elf64_Phdr);
+	e->e_phnum = e_phnum;
+	e->e_phoff = e->e_ehsize;
+	e->e_type = ET_CORE;
+	e->e_machine = e_machine;
+	e->e_version = EV_CURRENT;
+	e->e_flags = e_flags;
+
+	if (e_phnum == PN_XNUM) {
+		e->e_shoff = e->e_ehsize;
+		e->e_shentsize = sizeof(Elf64_Shdr);
+		e->e_shnum = 1;
+		e->e_shstrndx = SHN_UNDEF;
+		e->e_phoff = e->e_shoff + e->e_shentsize * e->e_shnum;
+	}
+}
+
+static void
+elf64_fill_section_header(struct gcore_elf_struct *this, int phnum)
+{
+	Elf64_Shdr *s = &((struct gcore_elf64_struct *)this)->shdr;
+
+	BZERO(s, sizeof(*s));
+
+	s->sh_type = SHT_NULL;
+	s->sh_size = 1;
+	s->sh_link = SHN_UNDEF;
+	s->sh_info = phnum;
+}
+
+static void
+elf64_fill_program_header(struct gcore_elf_struct *this, uint32_t p_type,
+			  uint32_t p_flags, uint64_t p_offset,
+			  uint64_t p_vaddr, uint64_t p_filesz,
+			  uint64_t p_memsz, uint64_t p_align)
+{
+	Elf64_Phdr *p = &((struct gcore_elf64_struct *)this)->phdr;
+
+	BZERO(p, sizeof(*p));
+
+	p->p_type = p_type;
+	p->p_flags = p_flags;
+	p->p_offset = p_offset;
+	p->p_vaddr = p_vaddr;
+	p->p_filesz = p_filesz;
+	p->p_memsz = p_memsz;
+	p->p_align = p_align;
+}
+
+static void
+elf64_fill_note_header(struct gcore_elf_struct *this, uint32_t n_namesz,
+		       uint32_t n_descsz, uint32_t n_type)
+{
+	Elf64_Nhdr *n = &((struct gcore_elf64_struct *)this)->nhdr;
+
+	BZERO(n, sizeof(*n));
+
+	n->n_namesz = n_namesz;
+	n->n_descsz = n_descsz;
+	n->n_type = n_type;
+}
+
+static int elf64_write_elf_header(struct gcore_elf_struct *this, FILE *fp)
+{
+	Elf64_Ehdr *e = &((struct gcore_elf64_struct *)this)->ehdr;
+
+	if (fwrite(e, sizeof(*e), 1, fp) != 1)
+		return FALSE;
+
+	return TRUE;
+}
+
+static int elf64_write_section_header(struct gcore_elf_struct *this, FILE *fp)
+{
+	Elf64_Shdr *s = &((struct gcore_elf64_struct *)this)->shdr;
+
+	if (fwrite(s, sizeof(*s), 1, fp) != 1)
+		return FALSE;
+
+	return TRUE;
+}
+
+static int elf64_write_program_header(struct gcore_elf_struct *this, FILE *fp)
+{
+	Elf64_Phdr *p = &((struct gcore_elf64_struct *)this)->phdr;
+
+	if (fwrite(p, sizeof(*p), 1, fp) != 1)
+		return FALSE;
+
+	return TRUE;
+}
+
+static int elf64_write_note_header(struct gcore_elf_struct *this, FILE *fp,
+				   off_t *offset)
+{
+	Elf64_Nhdr *n = &((struct gcore_elf64_struct *)this)->nhdr;
+
+	if (fwrite(n, sizeof(*n), 1, fp) != 1)
+		return FALSE;
+
+	*offset += sizeof(*n);
+
+	return TRUE;
+}
+
+static uint64_t elf64_get_e_phoff(struct gcore_elf_struct *this)
+{
+	return ((struct gcore_elf64_struct *)this)->ehdr.e_phoff;
+}
+
+static uint64_t elf64_get_e_shoff(struct gcore_elf_struct *this)
+{
+	return ((struct gcore_elf64_struct *)this)->ehdr.e_shoff;
+}
+
+static size_t elf64_get_note_header_size(struct gcore_elf_struct *this)
+{
+	return sizeof(((struct gcore_elf64_struct *)this)->nhdr);
+}
+
+static off_t
+elf64_calc_segment_offset(struct gcore_elf_struct *this)
+{
+	Elf64_Ehdr *e = &((struct gcore_elf64_struct *)this)->ehdr;
+	Elf64_Shdr *s = &((struct gcore_elf64_struct *)this)->shdr;
+
+	if (e->e_shoff)
+		return e->e_ehsize +
+			e->e_shnum * e->e_shentsize +
+			s->sh_info * e->e_phentsize;
+	else
+		return e->e_ehsize +
+			e->e_phnum * e->e_phentsize;
+}
+
+struct gcore_elf_operations gcore_elf64_operations = {
+	.fill_elf_header = elf64_fill_elf_header,
+	.fill_section_header = elf64_fill_section_header,
+	.fill_program_header = elf64_fill_program_header,
+	.fill_note_header = elf64_fill_note_header,
+
+	.write_elf_header = elf64_write_elf_header,
+	.write_section_header = elf64_write_section_header,
+	.write_program_header = elf64_write_program_header,
+	.write_note_header = elf64_write_note_header,
+
+	.get_e_phoff = elf64_get_e_phoff,
+	.get_e_shoff = elf64_get_e_shoff,
+
+	.get_note_header_size = elf64_get_note_header_size,
+
+	.calc_segment_offset = elf64_calc_segment_offset,
+};
+
+const struct gcore_elf_operations *gcore_elf64_get_operations(void)
+{
+	return &gcore_elf64_operations;
+}
+
+static void
+elf32_fill_elf_header(struct gcore_elf_struct *this, uint16_t e_phnum,
+		      uint16_t e_machine, uint32_t e_flags, uint8_t ei_osabi)
+{
+	Elf32_Ehdr *e = &((struct gcore_elf32_struct *)this)->ehdr;
+
+	BZERO(e, sizeof(*e));
+
+	BCOPY(ELFMAG, e->e_ident, SELFMAG);
+	e->e_ident[EI_CLASS] = ELFCLASS32;
+	e->e_ident[EI_DATA] = ELF_DATA;
+	e->e_ident[EI_VERSION] = EV_CURRENT;
+	e->e_ident[EI_OSABI] = ei_osabi;
+	e->e_ehsize = sizeof(Elf32_Ehdr);
+	e->e_phentsize = sizeof(Elf32_Phdr);
+	e->e_phnum = e_phnum;
+	e->e_type = ET_CORE;
+	e->e_machine = e_machine;
+	e->e_version = EV_CURRENT;
+	e->e_phoff = e->e_ehsize;
+	e->e_flags = e_flags;
+
+	if (e_phnum == PN_XNUM) {
+		e->e_shoff = e->e_ehsize;
+		e->e_shentsize = sizeof(Elf32_Shdr);
+		e->e_shnum = 1;
+		e->e_shstrndx = SHN_UNDEF;
+		e->e_phoff = e->e_shoff + e->e_shentsize * e->e_shnum;
+	}
+}
+
+static void
+elf32_fill_section_header(struct gcore_elf_struct *this, int phnum)
+{
+	Elf32_Shdr *s = &((struct gcore_elf32_struct *)this)->shdr;
+
+	BZERO(s, sizeof(*s));
+
+	s->sh_type = SHT_NULL;
+	s->sh_size = 1;
+	s->sh_link = SHN_UNDEF;
+	s->sh_info = phnum;
+}
+
+static void
+elf32_fill_program_header(struct gcore_elf_struct *this, uint32_t p_type,
+			  uint32_t p_flags, uint64_t p_offset,
+			  uint64_t p_vaddr, uint64_t p_filesz,
+			  uint64_t p_memsz, uint64_t p_align)
+{
+	Elf32_Phdr *p = &((struct gcore_elf32_struct *)this)->phdr;
+
+	BZERO(p, sizeof(*p));
+
+	p->p_type = p_type;
+	p->p_flags = p_flags;
+	p->p_offset = p_offset;
+	p->p_vaddr = p_vaddr;
+	p->p_filesz = p_filesz;
+	p->p_memsz = p_memsz;
+	p->p_align = p_align;
+}
+
+static void
+elf32_fill_note_header(struct gcore_elf_struct *this, uint32_t n_namesz,
+		       uint32_t n_descsz, uint32_t n_type)
+{
+	Elf32_Nhdr *n = &((struct gcore_elf32_struct *)this)->nhdr;
+
+	BZERO(n, sizeof(*n));
+
+	n->n_namesz = n_namesz;
+	n->n_descsz = n_descsz;
+	n->n_type = n_type;
+}
+
+static int elf32_write_elf_header(struct gcore_elf_struct *this, FILE *fp)
+{
+	Elf32_Ehdr *e = &((struct gcore_elf32_struct *)this)->ehdr;
+
+	if (fwrite(e, sizeof(*e), 1, fp) != 1)
+		return FALSE;
+
+	return TRUE;
+}
+
+static int elf32_write_section_header(struct gcore_elf_struct *this, FILE *fp)
+{
+	Elf32_Shdr *s = &((struct gcore_elf32_struct *)this)->shdr;
+
+	if (fwrite(s, sizeof(*s), 1, fp) != 1)
+		return FALSE;
+
+	return TRUE;
+}
+
+static int elf32_write_program_header(struct gcore_elf_struct *this, FILE *fp)
+{
+	Elf32_Phdr *p = &((struct gcore_elf32_struct *)this)->phdr;
+
+	if (fwrite(p, sizeof(*p), 1, fp) != 1)
+		return FALSE;
+
+	return TRUE;
+}
+
+static int elf32_write_note_header(struct gcore_elf_struct *this, FILE *fp,
+				   off_t *offset)
+{
+	Elf32_Nhdr *n = &((struct gcore_elf32_struct *)this)->nhdr;
+
+	if (fwrite(n, sizeof(*n), 1, fp) != 1)
+		return FALSE;
+
+	*offset += sizeof(*n);
+
+	return TRUE;
+}
+
+static uint64_t elf32_get_e_phoff(struct gcore_elf_struct *this)
+{
+	return ((struct gcore_elf32_struct *)this)->ehdr.e_phoff;
+}
+
+static uint64_t elf32_get_e_shoff(struct gcore_elf_struct *this)
+{
+	return ((struct gcore_elf32_struct *)this)->ehdr.e_shoff;
+}
+
+static size_t elf32_get_note_header_size(struct gcore_elf_struct *this)
+{
+	return sizeof(((struct gcore_elf32_struct *)this)->nhdr);
+}
+
+static off_t
+elf32_calc_segment_offset(struct gcore_elf_struct *this)
+{
+	Elf32_Ehdr *e = &((struct gcore_elf32_struct *)this)->ehdr;
+	Elf32_Shdr *s = &((struct gcore_elf32_struct *)this)->shdr;
+
+	if (e->e_shoff)
+		return e->e_ehsize +
+			e->e_shnum * e->e_shentsize +
+			s->sh_info * e->e_phentsize;
+	else
+		return e->e_ehsize +
+			e->e_phnum * e->e_phentsize;
+}
+
+struct gcore_elf_operations gcore_elf32_operations = {
+	.fill_elf_header = elf32_fill_elf_header,
+	.fill_section_header = elf32_fill_section_header,
+	.fill_program_header = elf32_fill_program_header,
+	.fill_note_header = elf32_fill_note_header,
+
+	.write_elf_header = elf32_write_elf_header,
+	.write_section_header = elf32_write_section_header,
+	.write_program_header = elf32_write_program_header,
+	.write_note_header = elf32_write_note_header,
+
+	.get_e_phoff = elf32_get_e_phoff,
+	.get_e_shoff = elf32_get_e_shoff,
+
+	.get_note_header_size = elf32_get_note_header_size,
+
+	.calc_segment_offset = elf32_calc_segment_offset,
+};
+
+const struct gcore_elf_operations *gcore_elf32_get_operations(void)
+{
+	return &gcore_elf32_operations;
+}
+
+/**
+ * Initialize ELF interface object.
+ * @gcore one session data whose elf field is initialized
+ *
+ * Precondition:
+ *
+ *   Nothing.
+ *
+ * Postcondition:
+ *
+ *   If the current task_context is a 32-bit task:
+ *
+ *     - gcore_elf32_struct structure is allocated to gcore->elf, and
+ *     - gcore->elf->ops == &gcore_elf32_operations.
+ *
+ *   Otherwise,
+ *
+ *     - gcore_elf64_struct structure is allocated to gcore->elf, and
+ *     - gcore->elf->ops == &gcore_elf64_operations.
+ *
+ * Return Value:
+ *
+ *   Nothing.
+ */
+void gcore_elf_init(struct gcore_one_session_data *gcore)
+{
+	size_t size;
+	struct gcore_elf_operations *ops;
+
+	if (BITS32() || gcore_is_arch_32bit_emulation(CURRENT_CONTEXT())) {
+		size = sizeof(struct gcore_elf32_struct);
+		ops = &gcore_elf32_operations;
+	} else {
+		size = sizeof(struct gcore_elf64_struct);
+		ops = &gcore_elf64_operations;
+	}
+
+	gcore->elf = (struct gcore_elf_struct *)GETBUF(size);
+	BZERO(gcore->elf, size);
+	gcore->elf->ops = ops;
+}

--- a/extensions/libgcore/gcore_global_data.c
+++ b/extensions/libgcore/gcore_global_data.c
@@ -1,0 +1,29 @@
+/* gcore_global_data.c -- core analysis suite
+ *
+ * Copyright (C) 2010, 2011 FUJITSU LIMITED
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <defs.h>
+#include <gcore_defs.h>
+
+static struct gcore_one_session_data gcore_one_session_data = {0, };
+struct gcore_one_session_data *gcore = &gcore_one_session_data;
+
+static struct gcore_coredump_table gcore_coredump_table = {0, };
+struct gcore_coredump_table *ggt = &gcore_coredump_table;
+
+struct gcore_offset_table gcore_offset_table = {0, };
+struct gcore_size_table gcore_size_table = {0, };
+
+struct gcore_machdep_table gcore_machdep_table;
+struct gcore_machdep_table *gcore_machdep = &gcore_machdep_table;

--- a/extensions/libgcore/gcore_mips.c
+++ b/extensions/libgcore/gcore_mips.c
@@ -1,0 +1,159 @@
+/* gcore_mips.c -- core analysis suite
+ *
+ * Copyright (C) 2016 Axis Communications
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+#if defined(MIPS)
+
+#include "defs.h"
+#include <gcore_defs.h>
+#include <stdint.h>
+#include <elf.h>
+#include <asm/ldt.h>
+
+#define MIPS32_EF_R0		6
+#define MIPS32_EF_R1		7
+#define MIPS32_EF_R26		32
+#define MIPS32_EF_R27		33
+#define MIPS32_EF_R31		37
+#define MIPS32_EF_LO		38
+#define MIPS32_EF_HI		39
+#define MIPS32_EF_CP0_EPC	40
+#define MIPS32_EF_CP0_BADVADDR	41
+#define MIPS32_EF_CP0_STATUS	42
+#define MIPS32_EF_CP0_CAUSE	43
+
+static int gpr_get(struct task_context *target,
+		       const struct user_regset *regset,
+		       unsigned int size, void *buf)
+{
+	static int once;
+	struct user_regs_struct *regs = buf;
+	struct mips_pt_regs_main *mains;
+	struct mips_pt_regs_cp0 *cp0;
+	char pt_regs[SIZE(pt_regs)];
+	int i;
+
+	/*
+	 * All registers are saved in thread_info.regs only on certain types of
+	 * entries to the kernel (such as abort handling).  For other types of
+	 * entries (such as system calls), only a subset of the registers are
+	 * saved on entry and the rest are saved on the stack according to the
+	 * ABI's calling conventions.  To always get the full register set we
+	 * would have to unwind the stack and find where the registers are by
+	 * using DWARF information.  We don't have an implementation for this
+	 * right now so warn to avoid misleading the user.  Only warn since
+	 * this function is called multiple times even for a single invocation
+	 * of the gcore command.
+	 */
+	if (!once) {
+		once = 1;
+		error(WARNING, "WARNING: Current register values may be inaccurate\n");
+	}
+
+	readmem(machdep->get_stacktop(target->task) - 32 - SIZE(pt_regs),
+		KVADDR, pt_regs, SIZE(pt_regs), "genregs_get: pt_regs",
+		gcore_verbose_error_handle());
+
+	mains = (struct mips_pt_regs_main *) (pt_regs + OFFSET(pt_regs_regs));
+	cp0 = (struct mips_pt_regs_cp0 *) \
+	      (pt_regs + OFFSET(pt_regs_cp0_badvaddr));
+
+	BZERO(regs, sizeof(*regs));
+
+	for (i = MIPS32_EF_R1; i <= MIPS32_EF_R31; i++) {
+		/* k0/k1 are copied as zero. */
+		if (i == MIPS32_EF_R26 || i == MIPS32_EF_R27)
+			continue;
+
+		regs->gregs[i] = mains->regs[i - MIPS32_EF_R0];
+	}
+
+	regs->gregs[MIPS32_EF_LO] = mains->lo;
+	regs->gregs[MIPS32_EF_HI] = mains->hi;
+	regs->gregs[MIPS32_EF_CP0_EPC] = cp0->cp0_epc;
+	regs->gregs[MIPS32_EF_CP0_BADVADDR] = cp0->cp0_badvaddr;
+	regs->gregs[MIPS32_EF_CP0_STATUS] = mains->cp0_status;
+	regs->gregs[MIPS32_EF_CP0_CAUSE] = cp0->cp0_cause;
+
+	return 0;
+}
+
+enum gcore_regset {
+	REGSET_GPR,
+};
+
+static struct user_regset mips_regsets[] = {
+	[REGSET_GPR] = {
+		.core_note_type = NT_PRSTATUS,
+		.name = "CORE",
+		.size = ELF_NGREG * sizeof(unsigned int),
+		.get = gpr_get,
+	},
+};
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+#endif
+
+static const struct user_regset_view mips_regset_view = {
+	.name = "mips",
+	.regsets = mips_regsets,
+	.n = ARRAY_SIZE(mips_regsets),
+	.e_machine = EM_MIPS,
+};
+
+const struct user_regset_view *
+task_user_regset_view(void)
+{
+	return &mips_regset_view;
+}
+
+int gcore_is_arch_32bit_emulation(struct task_context *tc)
+{
+	return FALSE;
+}
+
+ulong gcore_arch_get_gate_vma(void)
+{
+	return 0UL;
+}
+
+char *gcore_arch_vma_name(ulong vma)
+{
+	ulong mm, vm_start, vdso;
+
+	readmem(vma + OFFSET(vm_area_struct_vm_mm), KVADDR, &mm, sizeof(mm),
+		"gcore_arch_vma_name: vma->vm_mm",
+		gcore_verbose_error_handle());
+
+	readmem(vma + OFFSET(vm_area_struct_vm_start), KVADDR, &vm_start,
+		sizeof(vm_start), "gcore_arch_vma_name: vma->vm_start",
+		gcore_verbose_error_handle());
+
+	readmem(mm + GCORE_OFFSET(mm_struct_context) +
+		GCORE_OFFSET(mm_context_t_vdso), KVADDR, &vdso,
+		sizeof(vdso), "gcore_arch_vma_name: mm->context.vdso",
+		gcore_verbose_error_handle());
+
+	if (mm && vm_start == vdso)
+		return "[vdso]";
+
+	return NULL;
+}
+
+int gcore_arch_vsyscall_has_vm_alwaysdump_flag(void)
+{
+	return FALSE;
+}
+
+#endif /* defined(MIPS) */

--- a/extensions/libgcore/gcore_ppc64.c
+++ b/extensions/libgcore/gcore_ppc64.c
@@ -1,0 +1,90 @@
+/* gcore_ppc64.c
+ *
+ * Copyright (C) 2014 Red Hat, Inc. All rights reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifdef PPC64
+
+#include "defs.h"
+#include <gcore_defs.h>
+#include <stdint.h>
+#include <elf.h>
+
+static int gpr_get(struct task_context *target,
+                   const struct user_regset *regset,
+                   unsigned int size, void *buf)
+{
+	struct user_regs_struct *regs = (struct user_regs_struct *)buf;
+
+	BZERO(regs, sizeof(*regs));
+
+	readmem(machdep->get_stacktop(target->task) - SIZE(pt_regs), KVADDR,
+		regs, SIZE(pt_regs), "genregs_get: pt_regs",
+		gcore_verbose_error_handle());
+
+	return 0;
+}
+
+enum gcore_regset {
+	REGSET_GPR,
+};
+
+static struct user_regset ppc64_regsets[] = {
+	[REGSET_GPR] = {
+		.core_note_type = NT_PRSTATUS,
+		.name = "CORE",
+		.size = ELF_NGREG * sizeof(unsigned int),
+		.get = gpr_get,
+	},
+};
+
+static const struct user_regset_view ppc64_regset_view = {
+	.name = "ppc64",
+	.regsets = ppc64_regsets,
+	.n = 1,
+	.e_machine = EM_PPC64,
+};
+
+const struct user_regset_view *
+task_user_regset_view(void)
+{
+	return &ppc64_regset_view;
+}
+
+int gcore_is_arch_32bit_emulation(struct task_context *tc)
+{
+	return FALSE;
+}
+
+/**
+ * Return an address to gate_vma.
+ */
+ulong gcore_arch_get_gate_vma(void)
+{
+	if (!symbol_exists("gate_vma"))
+		return 0UL;
+
+	return symbol_value("gate_vma");
+}
+
+char *gcore_arch_vma_name(ulong vma)
+{
+	return NULL;
+}
+
+int gcore_arch_vsyscall_has_vm_alwaysdump_flag(void)
+{
+	return FALSE;
+}
+
+#endif

--- a/extensions/libgcore/gcore_regset.c
+++ b/extensions/libgcore/gcore_regset.c
@@ -1,0 +1,66 @@
+/* regset.c -- core analysis suite
+ *
+ * Copyright (C) 2010, 2011 FUJITSU LIMITED
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "defs.h"
+#include <gcore_defs.h>
+#include <elf.h>
+
+enum gcore_default_regset {
+	REGSET_GENERAL,
+};
+
+static int genregs_get(struct task_context *target,
+		       const struct user_regset *regset,
+		       unsigned int size,
+		       void *buf)
+{
+	readmem(machdep->get_stacktop(target->task) - SIZE(pt_regs), KVADDR,
+		buf, size, "genregs_get: pt_regs", gcore_verbose_error_handle());
+
+	return 0;
+}
+
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+
+static struct user_regset gcore_default_regsets[] = {
+	[REGSET_GENERAL] = {
+		.core_note_type = NT_PRSTATUS,
+		.get = genregs_get
+	},
+};
+
+static struct user_regset_view gcore_default_regset_view = {
+	.name = REGSET_VIEW_NAME,
+	.regsets = gcore_default_regsets,
+	.n = ARRAY_SIZE(gcore_default_regsets),
+	.e_machine = REGSET_VIEW_MACHINE
+};
+
+const struct user_regset_view * __attribute__((weak))
+task_user_regset_view(void)
+{
+	return &gcore_default_regset_view;
+}
+
+void gcore_default_regsets_init(void)
+{
+	gcore_default_regsets[REGSET_GENERAL].size = SIZE(pt_regs);
+}
+
+int __attribute__((weak))
+gcore_arch_get_fp_valid(struct task_context *tc)
+{
+	return 0;
+}

--- a/extensions/libgcore/gcore_verbose.c
+++ b/extensions/libgcore/gcore_verbose.c
@@ -1,0 +1,92 @@
+/* gcore_verbose.c -- core analysis suite
+ *
+ * Copyright (C) 2010, 2011 FUJITSU LIMITED
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "defs.h"
+#include <gcore_defs.h>
+
+struct gcore_verbose_data
+{
+	ulong level;
+	ulong error_handle;
+};
+
+static struct gcore_verbose_data gcore_verbose_data = { 0 };
+static struct gcore_verbose_data *gvd = &gcore_verbose_data;
+
+/**
+ * set current verbose state to the default
+ *
+ * Precondition:
+ *
+ *   Nothing.
+ *
+ * Postcondition:
+ *
+ *   - gcore_verbose_get() == VERBOSE_DEFAULT_LEVEL
+ *   - gcore_verbose_error_handle() == VERBOSE_DEFAULT_ERROR_HANDLE
+ *
+ * Return Value:
+ *
+ *   Nothing.
+ */
+void gcore_verbose_set_default(void)
+{
+	gvd->level = VERBOSE_DEFAULT_LEVEL;
+	gvd->error_handle = VERBOSE_DEFAULT_ERROR_HANDLE;
+}
+
+/**
+ * set current verbose state to the one corresponding to a given level
+ *
+ * @level verbose level to be set
+ *
+ * Precondition:
+ *
+ *   Nothing.
+ *
+ * Postcondition:
+ *
+ *   If 0 <= @level <= VERBOSE_MAX_LEVEL, gcore_verbose_get() ==
+ *   @level. If VERBOSE_NONQUIET is set to @level, QUIET is unset to
+ *   gcore_verbose_error_handle(). If VERBOSE_NONQUIET is set, QUIET
+ *   is set conversely. If @level > VERBOSE_MAX_LEVEL, the state
+ *   remains the same.
+ *
+ * Return Value:
+ *
+ *   If 0 <= @level <= VERBOSE_MAX_LEVEL, return TRUE. Otherwise,
+ *   return FALSE.
+ */
+int gcore_verbose_set(ulong level)
+{
+	if (level > VERBOSE_MAX_LEVEL)
+		return FALSE;
+	gvd->level = level;
+	if (gvd->level & VERBOSE_NONQUIET)
+		gvd->error_handle &= ~QUIET;
+	else
+		gvd->error_handle |= QUIET;
+	return TRUE;
+}
+
+ulong gcore_verbose_get(void)
+{
+	return gvd->level;
+}
+
+ulong gcore_verbose_error_handle(void)
+{
+	return gvd->error_handle;
+}

--- a/extensions/libgcore/gcore_x86.c
+++ b/extensions/libgcore/gcore_x86.c
@@ -1,0 +1,2511 @@
+/* x86.c -- core analysis suite
+ *
+ * Copyright (C) 2010, 2011 FUJITSU LIMITED
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+#if defined(X86) || defined(X86_64)
+
+#include "defs.h"
+#include <gcore_defs.h>
+#include <stdint.h>
+#include <elf.h>
+#include <asm/ldt.h>
+
+#undef MIN
+#define MIN(X,Y) (((X) < (Y)) ? (X) : (Y))
+
+struct gcore_x86_table
+{
+#ifdef X86_64
+	ulong (*get_old_rsp)(int cpu);
+	ulong (*user_stack_pointer)(struct task_context *tc);
+#endif
+	ulong (*get_thread_struct_fpu)(struct task_context *tc);
+	ulong (*get_thread_struct_fpu_size)(void);
+#ifdef X86_64
+	int (*is_special_syscall)(int nr_syscall);
+	int (*is_special_ia32_syscall)(int nr_syscall);
+#endif
+	int (*tsk_used_math)(ulong task);
+};
+
+static struct gcore_x86_table gcore_x86_table;
+struct gcore_x86_table *gxt = &gcore_x86_table;
+
+#ifdef X86_64
+static ulong gcore_x86_64_get_old_rsp(int cpu);
+static ulong gcore_x86_64_get_per_cpu__old_rsp(int cpu);
+static ulong gcore_x86_64_get_cpu_pda_oldrsp(int cpu);
+static ulong gcore_x86_64_get_cpu__pda_oldrsp(int cpu);
+
+static ulong gcore_x86_64_user_stack_pointer_userrsp(struct task_context *tc);
+static ulong gcore_x86_64_user_stack_pointer_pt_regs(struct task_context *tc);
+#endif
+
+static ulong
+gcore_x86_get_thread_struct_fpu_fpregs_state(struct task_context *tc);
+static ulong
+gcore_x86_get_thread_struct_fpu_thread_xstate(struct task_context *tc);
+static ulong gcore_x86_get_thread_struct_fpu_thread_xstate_size(void);
+static ulong
+gcore_x86_get_thread_struct_thread_xstate(struct task_context *tc);
+static ulong gcore_x86_get_thread_struct_thread_xstate_size(void);
+static ulong gcore_x86_get_thread_struct_i387(struct task_context *tc);
+static ulong gcore_x86_get_thread_struct_i387_size(void);
+
+#ifdef X86_64
+static void gcore_x86_table_register_get_old_rsp(void);
+#endif
+static void gcore_x86_table_register_get_thread_struct_fpu(void);
+#ifdef X86_64
+static void gcore_x86_table_register_is_special_syscall(void);
+static void gcore_x86_table_register_is_special_ia32_syscall(void);
+#endif
+static void gcore_x86_table_register_tsk_used_math(void);
+
+#ifdef X86_64
+static int is_special_syscall_v0(int nr_syscall);
+static int is_special_syscall_v26(int nr_syscall);
+#endif
+
+static int test_bit(unsigned int nr, const ulong addr);
+
+#ifdef X86_64
+static int is_ia32_syscall_enabled(void);
+static int is_special_ia32_syscall_v0(int nr_syscall);
+static int is_special_ia32_syscall_v26(int nr_syscall);
+#endif
+
+static int tsk_used_math_v0(ulong task);
+static int tsk_used_math_v11(ulong task);
+static int tsk_used_math_v4_14(ulong task);
+
+#ifdef X86_64
+static void gcore_x86_64_regset_xstate_init(void);
+#endif
+
+static int genregs_get32(struct task_context *target,
+			 const struct user_regset *regset, unsigned int size,
+			 void *buf);
+#ifdef X86
+static void gcore_x86_32_regset_xstate_init(void);
+#endif
+
+static int get_xstate_regsets_number(void);
+
+enum gcore_regset {
+	REGSET_GENERAL,
+	REGSET_FP,
+	REGSET_XFP,
+	REGSET_IOPERM64 = REGSET_XFP,
+	REGSET_TLS,
+	REGSET_IOPERM32,
+	REGSET_XSTATE,
+};
+
+#define NT_386_TLS      0x200           /* i386 TLS slots (struct user_desc) */
+#ifndef NT_386_IOPERM
+#define NT_386_IOPERM	0x201		/* x86 io permission bitmap (1=deny) */
+#endif
+#define NT_X86_XSTATE   0x202           /* x86 extended state using xsave */
+#define NT_PRXFPREG     0x46e62b7f      /* copied from gdb5.1/include/elf/common.h */
+
+#define USER_XSTATE_FX_SW_WORDS 6
+
+#define MXCSR_DEFAULT           0x1f80
+
+#ifdef X86_64
+/* This matches the 64bit FXSAVE format as defined by AMD. It is the same
+   as the 32bit format defined by Intel, except that the selector:offset pairs for
+   data and eip are replaced with flat 64bit pointers. */ 
+struct user_i387_struct {
+	unsigned short	cwd;
+	unsigned short	swd;
+	unsigned short	twd; /* Note this is not the same as the 32bit/x87/FSAVE twd */
+	unsigned short	fop;
+	uint64_t	rip;
+	uint64_t	rdp;
+	uint32_t	mxcsr;
+	uint32_t	mxcsr_mask;
+	uint32_t	st_space[32];	/* 8*16 bytes for each FP-reg = 128 bytes */
+	uint32_t	xmm_space[64];	/* 16*16 bytes for each XMM-reg = 256 bytes */
+	uint32_t	padding[24];
+};
+#endif
+
+struct user_i387_ia32_struct {
+	uint32_t	cwd;
+	uint32_t	swd;
+	uint32_t	twd;
+	uint32_t	fip;
+	uint32_t	fcs;
+	uint32_t	foo;
+	uint32_t	fos;
+	uint32_t	st_space[20];   /* 8*10 bytes for each FP-reg = 80 bytes */
+};
+
+struct user32_fxsr_struct {
+	unsigned short	cwd;
+	unsigned short	swd;
+	unsigned short	twd;	/* not compatible to 64bit twd */
+	unsigned short	fop;
+	int	fip;
+	int	fcs;
+	int	foo;
+	int	fos;
+	int	mxcsr;
+	int	reserved;
+	int	st_space[32];	/* 8*16 bytes for each FP-reg = 128 bytes */
+	int	xmm_space[32];	/* 8*16 bytes for each XMM-reg = 128 bytes */
+	int	padding[56];
+};
+
+struct i387_fsave_struct {
+        uint32_t                     cwd;    /* FPU Control Word             */
+        uint32_t                     swd;    /* FPU Status Word              */
+        uint32_t                     twd;    /* FPU Tag Word                 */
+        uint32_t                     fip;    /* FPU IP Offset                */
+        uint32_t                     fcs;    /* FPU IP Selector              */
+        uint32_t                     foo;    /* FPU Operand Pointer Offset   */
+        uint32_t                     fos;    /* FPU Operand Pointer Selector */
+
+        /* 8*10 bytes for each FP-reg = 80 bytes:                       */
+        uint32_t                     st_space[20];
+
+        /* Software status information [not touched by FSAVE ]:         */
+        uint32_t                     status;
+};
+
+struct i387_fxsave_struct {
+        uint16_t                     cwd; /* Control Word                    */
+        uint16_t                     swd; /* Status Word                     */
+        uint16_t                     twd; /* Tag Word                        */
+        uint16_t                     fop; /* Last Instruction Opcode         */
+        union {
+                struct {
+                        uint64_t     rip; /* Instruction Pointer             */
+                        uint64_t     rdp; /* Data Pointer                    */
+                };
+                struct {
+                        uint32_t     fip; /* FPU IP Offset                   */
+                        uint32_t     fcs; /* FPU IP Selector                 */
+                        uint32_t     foo; /* FPU Operand Offset              */
+                        uint32_t     fos; /* FPU Operand Selector            */
+                };
+        };
+        uint32_t                     mxcsr;          /* MXCSR Register State */
+        uint32_t                     mxcsr_mask;     /* MXCSR Mask           */
+
+        /* 8*16 bytes for each FP-reg = 128 bytes:                      */
+        uint32_t                     st_space[32];
+
+        /* 16*16 bytes for each XMM-reg = 256 bytes:                    */
+        uint32_t                     xmm_space[64];
+
+        uint32_t                     padding[12];
+
+        union {
+                uint32_t             padding1[12];
+                uint32_t             sw_reserved[12];
+        };
+
+} __attribute__((aligned(16)));
+
+struct i387_soft_struct {
+        uint32_t                     cwd;
+        uint32_t                     swd;
+        uint32_t                     twd;
+        uint32_t                     fip;
+        uint32_t                     fcs;
+        uint32_t                     foo;
+        uint32_t                     fos;
+        /* 8*10 bytes for each FP-reg = 80 bytes: */
+        uint32_t                     st_space[20];
+        uint8_t                      ftop;
+        uint8_t                      changed;
+        uint8_t                      lookahead;
+        uint8_t                      no_update;
+        uint8_t                      rm;
+        uint8_t                      alimit;
+        struct math_emu_info    *info;
+        uint32_t                     entry_eip;
+};
+
+struct ymmh_struct {
+        /* 16 * 16 bytes for each YMMH-reg = 256 bytes */
+        uint32_t ymmh_space[64];
+};
+
+struct xsave_hdr_struct {
+        uint64_t xstate_bv;
+        uint64_t reserved1[2];
+        uint64_t reserved2[5];
+} __attribute__((packed));
+
+struct xsave_struct {
+        struct i387_fxsave_struct i387;
+        struct xsave_hdr_struct xsave_hdr;
+        struct ymmh_struct ymmh;
+        /* new processor state extensions will go here */
+} __attribute__ ((packed, aligned (64)));
+
+union thread_xstate {
+        struct i387_fsave_struct        fsave;
+        struct i387_fxsave_struct       fxsave;
+        struct i387_soft_struct         soft;
+        struct xsave_struct             xsave;
+};
+
+#define NCAPINTS	9	/* N 32-bit words worth of info */
+
+#define X86_FEATURE_FXSR	(0*32+24) /* FXSAVE/FXRSTOR, CR4.OSFXSR */
+#define X86_FEATURE_XSAVE       (4*32+26) /* XSAVE/XRSTOR/XSETBV/XGETBV */
+#define X86_FEATURE_XSAVEOPT	(7*32+ 4) /* Optimized Xsave */
+
+/*
+ * Per process flags
+ */
+#define PF_USED_MATH    0x00002000      /* if unset the fpu must be initialized before use */
+
+/*
+ * Thread-synchronous status.
+ *
+ * This is different from the flags in that nobody else
+ * ever touches our thread-synchronous status, so we don't
+ * have to worry about atomic accesses.
+ */
+#define TS_USEDFPU		0x0001	/* FPU was used by this task
+					   this quantum (SMP) */
+
+static int
+boot_cpu_has(int feature)
+{
+	uint32_t x86_capability[NCAPINTS];
+
+	if (!symbol_exists("boot_cpu_data"))
+		error(FATAL, "boot_cpu_data: symbol does not exist\n");
+
+	readmem(symbol_value("boot_cpu_data") +
+		GCORE_OFFSET(cpuinfo_x86_x86_capability), KVADDR,
+		&x86_capability, sizeof(x86_capability),
+		"boot_cpu_has: x86_capability",
+		gcore_verbose_error_handle());
+
+	return ((1UL << (feature % 32)) & x86_capability[feature / 32]) != 0;
+}
+
+static inline int
+cpu_has_xsave(void)
+{
+	return boot_cpu_has(X86_FEATURE_XSAVE);
+}
+
+static inline int
+cpu_has_xsaveopt(void)
+{
+	return boot_cpu_has(X86_FEATURE_XSAVEOPT);
+}
+
+static inline int
+cpu_has_fxsr(void)
+{
+	return boot_cpu_has(X86_FEATURE_FXSR);
+}
+
+static int
+task_used_fpu(ulong task)
+{
+	uint32_t status;
+
+	readmem(task_to_context(task)->thread_info +
+		GCORE_OFFSET(thread_info_status), KVADDR, &status,
+		sizeof(uint32_t), "task_used_fpu: status",
+		gcore_verbose_error_handle());
+
+	return !!(status & TS_USEDFPU);
+}
+
+static void
+init_fpu(ulong task)
+{
+	if (gxt->tsk_used_math(task) && is_task_active(task)
+	    && task_used_fpu(task)) {
+		/*
+		 * The FPU values contained within thread->xstate may
+		 * differ from what was contained at crash timing, but
+		 * crash dump cannot restore the runtime FPU state,
+		 * here I only warn that.
+		 */
+		error(WARNING, "FPU may be inaccurate: %d\n",
+		      task_to_pid(task));
+        }
+}
+
+static int
+xfpregs_active(struct task_context *target,
+	       const struct user_regset *regset)
+{
+	return gxt->tsk_used_math(target->task);
+}
+
+static int xfpregs_get(struct task_context *target,
+		       const struct user_regset *regset,
+		       unsigned int size,
+		       void *buf)
+{
+	union thread_xstate xstate;
+
+	readmem(gxt->get_thread_struct_fpu(target), KVADDR, &xstate,
+		sizeof(xstate),
+		"xfpregs_get: xstate", gcore_verbose_error_handle());
+	memcpy(buf, &xstate.fsave, MIN(size, sizeof(xstate.fsave)));
+
+	init_fpu(target->task);
+
+	return 0;
+}
+
+static inline int
+fpregs_active(struct task_context *target,
+	      const struct user_regset *regset)
+{
+	return !!gxt->tsk_used_math(target->task);
+}
+
+static void sanitize_i387_state(struct task_context *target)
+{
+	if (cpu_has_xsaveopt()) {
+		/*
+		 * I have yet to implement here since I don't have
+		 * CPUes that supports XSAVEOPT instruction.
+		 */
+	}
+}
+
+#ifdef X86_64
+static inline int have_hwfp(void)
+{
+	return TRUE;
+}
+#else
+
+/*
+ * CONFIG_MATH_EMULATION is set iff there's no math_emulate().
+ */
+static int is_set_config_math_emulation(void)
+{
+	return !symbol_exists("math_emulate");
+}
+
+static int have_hwfp(void)
+{
+	char hard_math;
+
+	if (!is_set_config_math_emulation())
+		return TRUE;
+
+	readmem(symbol_value("cpuinfo_x86") + GCORE_OFFSET(cpuinfo_x86_hard_math),
+		KVADDR, &hard_math, sizeof(hard_math), "have_hwfp: hard_math",
+		gcore_verbose_error_handle());
+
+	return hard_math ? TRUE : FALSE;
+}
+#endif /* X86_64 */
+
+static int fpregs_soft_get(struct task_context *target,
+			   const struct user_regset *regset,
+			   unsigned int size,
+			   void *buf)
+{
+	error(WARNING, "not support FPU software emulation\n");
+	return 0;
+}
+
+static inline struct _fpxreg *
+fpreg_addr(struct i387_fxsave_struct *fxsave, int n)
+{
+	return (void *)&fxsave->st_space + n * 16;
+}
+
+static inline uint32_t
+twd_fxsr_to_i387(struct i387_fxsave_struct *fxsave)
+{
+	struct _fpxreg *st;
+	uint32_t tos = (fxsave->swd >> 11) & 7;
+	uint32_t twd = (unsigned long) fxsave->twd;
+	enum {
+		FP_EXP_TAG_VALID=0,
+		FP_EXP_TAG_ZERO,
+		FP_EXP_TAG_SPECIAL,
+		FP_EXP_TAG_EMPTY,
+	} tag;
+	uint32_t ret = 0xffff0000u;
+	int i;
+
+	for (i = 0; i < 8; i++, twd >>= 1) {
+		if (twd & 0x1) {
+			st = fpreg_addr(fxsave, (i - tos) & 7);
+
+			switch (st->exponent & 0x7fff) {
+			case 0x7fff:
+				tag = FP_EXP_TAG_SPECIAL;
+				break;
+			case 0x0000:
+				if (!st->significand[0] &&
+				    !st->significand[1] &&
+				    !st->significand[2] &&
+				    !st->significand[3])
+					tag = FP_EXP_TAG_ZERO;
+				else
+					tag = FP_EXP_TAG_SPECIAL;
+				break;
+			default:
+				if (st->significand[3] & 0x8000)
+					tag = FP_EXP_TAG_VALID;
+				else
+					tag = FP_EXP_TAG_SPECIAL;
+				break;
+			}
+		} else {
+			tag = FP_EXP_TAG_EMPTY;
+		}
+		ret |= (uint32_t)tag << (2 * i);
+	}
+	return ret;
+}
+
+static void
+convert_from_fxsr(struct user_i387_ia32_struct *env, struct task_context *target)
+{
+	union thread_xstate xstate;
+	struct _fpreg *to;
+	struct _fpxreg *from;
+	int i;
+
+	readmem(gxt->get_thread_struct_fpu(target), KVADDR, &xstate,
+		sizeof(xstate), "convert_from_fxsr: xstate",
+		gcore_verbose_error_handle());
+
+	to = (struct _fpreg *) &env->st_space[0];
+	from = (struct _fpxreg *) &xstate.fxsave.st_space[0];
+
+	env->cwd = xstate.fxsave.cwd | 0xffff0000u;
+	env->swd = xstate.fxsave.swd | 0xffff0000u;
+	env->twd = twd_fxsr_to_i387(&xstate.fxsave);
+
+#ifdef X86_64
+	env->fip = xstate.fxsave.rip;
+	env->foo = xstate.fxsave.rdp;
+	if (is_task_active(target->task)) {
+		error(WARNING, "cannot restore runtime fos and fcs\n");
+	} else {
+		char *pt_regs_buf;
+		uint16_t ds;
+		struct machine_specific *ms = machdep->machspec;
+
+		pt_regs_buf = GETBUF(SIZE(pt_regs));
+
+		readmem(machdep->get_stacktop(target->task) - SIZE(pt_regs),
+			KVADDR,	pt_regs_buf, SIZE(pt_regs),
+			"convert_from_fxsr: regs",
+			gcore_verbose_error_handle());
+
+		readmem(target->task + OFFSET(task_struct_thread)
+			+ GCORE_OFFSET(thread_struct_ds), KVADDR, &ds,
+			sizeof(ds), "convert_from_fxsr: ds",
+			gcore_verbose_error_handle());
+			
+		env->fos = 0xffff0000 | ds;
+		env->fcs = ULONG(pt_regs_buf + ms->pto.cs);
+
+		FREEBUF(pt_regs_buf);
+	}
+#endif
+
+#ifdef X86
+	env->fip = xstate.fxsave.fip;
+	env->fcs = (uint16_t) xstate.fxsave.fcs | ((uint32_t) xstate.fxsave.fop << 16);
+	env->foo = xstate.fxsave.foo;
+	env->fos = xstate.fxsave.fos;
+#endif
+
+	for (i = 0; i < 8; ++i)
+		memcpy(&to[i], &from[i], sizeof(to[0]));
+}
+
+static int fpregs_get(struct task_context *target,
+		      const struct user_regset *regset,
+		      unsigned int size,
+		      void *buf)
+{
+	union thread_xstate xstate;
+
+	init_fpu(target->task);
+
+	if (!have_hwfp())
+		return fpregs_soft_get(target, regset, size, buf);
+
+	if (!cpu_has_fxsr()) {
+		readmem(gxt->get_thread_struct_fpu(target), KVADDR, &xstate,
+			sizeof(xstate),
+			"fpregs_get: xstate", gcore_verbose_error_handle());
+		memcpy(buf, &xstate.fsave, MIN(size, sizeof(xstate.fsave)));
+		return 0;
+	}
+
+	sanitize_i387_state(target);
+
+	convert_from_fxsr(buf, target);
+
+        return 0;
+}
+
+static ulong gcore_x86_get_thread_struct_fpu_fpregs_state(struct task_context *tc)
+{
+	return tc->task +
+		OFFSET(task_struct_thread) +
+		GCORE_OFFSET(thread_struct_fpu) +
+		GCORE_OFFSET(fpu_state);
+}
+
+static ulong gcore_x86_get_thread_struct_fpu_thread_xstate(struct task_context *tc)
+{
+	ulong state;
+
+	readmem(tc->task + OFFSET(task_struct_thread)
+		+ GCORE_OFFSET(thread_struct_fpu) + GCORE_OFFSET(fpu_state),
+		KVADDR, &state, sizeof(state),
+		"gcore_x86_get_thread_struct_fpu_thread_xstate: state",
+		gcore_verbose_error_handle());
+
+	return state;
+}
+
+static ulong gcore_x86_get_thread_struct_fpu_thread_xstate_size(void)
+{
+#ifdef X86_64
+	return sizeof(struct user_i387_struct);
+#else
+	return sizeof(struct user_i387_ia32_struct);
+#endif
+}
+
+static ulong gcore_x86_get_thread_struct_thread_xstate(struct task_context *tc)
+{
+	ulong xstate;
+
+	readmem(tc->task + OFFSET(task_struct_thread)
+		+ GCORE_OFFSET(thread_struct_xstate), KVADDR, &xstate,
+		sizeof(xstate),
+		"gcore_x86_get_thread_struct_thread_xstate: xstate",
+		gcore_verbose_error_handle());
+
+	return xstate;
+}
+
+static ulong gcore_x86_get_thread_struct_thread_xstate_size(void)
+{
+	return GCORE_SIZE(thread_xstate);
+}
+
+static ulong gcore_x86_get_thread_struct_i387(struct task_context *tc)
+{
+	return tc->task + OFFSET(task_struct_thread)
+		+ GCORE_OFFSET(thread_struct_i387);
+}
+
+static ulong gcore_x86_get_thread_struct_i387_size(void)
+{
+	return GCORE_SIZE(i387_union);
+}
+
+/*
+ * For an entry for REGSET_XSTATE both on x86 and x86_64, member n is
+ * initiliazed dinamically at boot time.
+ */
+static int get_xstate_regsets_number(void)
+{
+	struct datatype_member datatype_member, *dm;
+	ulong x86_64_regsets_xstate;
+	unsigned int n;
+
+	if (!symbol_exists("REGSET_XSTATE"))
+		return 0;
+
+	dm = &datatype_member;
+
+	if (!arg_to_datatype("REGSET_XSTATE", dm, RETURN_ON_ERROR))
+		return 0;
+
+	x86_64_regsets_xstate = symbol_value("x86_64_regsets") +
+		dm->value * STRUCT_SIZE("user_regset");
+
+	readmem(x86_64_regsets_xstate + GCORE_OFFSET(user_regset_n),
+		KVADDR, &n, sizeof(n), "fpregs_active: n", FAULT_ON_ERROR);
+
+	return n;
+}
+
+static inline int
+xstateregs_active(struct task_context *target,
+		  const struct user_regset *regset)
+{
+	return cpu_has_xsave() && fpregs_active(target, regset)
+		&& symbol_exists("xstate_fx_sw_bytes")
+		&& !!get_xstate_regsets_number();
+}
+
+static int
+xstateregs_get(struct task_context *target,
+	       const struct user_regset *regset,
+	       unsigned int size,
+	       void *buf)
+{
+	union thread_xstate *xstate = (union thread_xstate *)buf;
+	ulong xstate_fx_sw_bytes;
+
+	readmem(target->task + OFFSET(task_struct_thread) +
+		GCORE_OFFSET(thread_struct_xstate), KVADDR, xstate,
+		sizeof(union thread_xstate), "xstateregs_get: thread",
+		gcore_verbose_error_handle());
+
+        init_fpu(target->task);
+
+	xstate_fx_sw_bytes = symbol_value("xstate_fx_sw_bytes");
+
+        /*
+         * Copy the 48bytes defined by the software first into the xstate
+         * memory layout in the thread struct, so that we can copy the entire
+         * xstateregs to the user using one user_regset_copyout().
+         */
+	readmem(xstate_fx_sw_bytes, KVADDR, &xstate->fxsave.sw_reserved,
+		USER_XSTATE_FX_SW_WORDS * sizeof(uint64_t),
+		"fill_xstate: sw_reserved", gcore_verbose_error_handle());
+
+	return 0;
+}
+
+#ifdef X86_64
+/*
+ * we cannot use the same code segment descriptor for user and kernel
+ * -- not even in the long flat mode, because of different DPL /kkeil
+ * The segment offset needs to contain a RPL. Grr. -AK
+ * GDT layout to get 64bit syscall right (sysret hardcodes gdt offsets)
+ */
+#define GDT_ENTRY_TLS_MIN 12
+#endif
+
+#ifdef X86
+#define GDT_ENTRY_TLS_MIN 6
+#endif
+
+#define GDT_ENTRY_TLS_ENTRIES 3
+
+/* TLS indexes for 64bit - hardcoded in arch_prctl */
+#define FS_TLS 0
+#define GS_TLS 1
+
+#define GS_TLS_SEL ((GDT_ENTRY_TLS_MIN+GS_TLS)*8 + 3)
+#define FS_TLS_SEL ((GDT_ENTRY_TLS_MIN+FS_TLS)*8 + 3)
+
+/*
+ * EFLAGS bits
+ */
+#define X86_EFLAGS_TF   0x00000100 /* Trap Flag */
+
+#define __USER_DS 0x2b
+#define __USER_CS 0x33
+
+/*
+ * thread information flags
+ * - these are process state flags that various assembly files
+ *   may need to access
+ * - pending work-to-be-done flags are in LSW
+ * - other flags in MSW
+ * Warning: layout of LSW is hardcoded in entry.S
+ */
+#define TIF_FORCED_TF           24      /* true if TF in eflags artificially */
+
+struct desc_struct {
+	uint16_t limit0;
+	uint16_t base0;
+	unsigned int base1: 8, type: 4, s: 1, dpl: 2, p: 1;
+	unsigned int limit: 4, avl: 1, l: 1, d: 1, g: 1, base2: 8;
+} __attribute__((packed));
+
+static inline ulong get_desc_base(const struct desc_struct *desc)
+{
+	return (ulong)(desc->base0 | ((desc->base1) << 16) | ((desc->base2) << 24));
+}
+
+static inline ulong get_desc_limit(const struct desc_struct *desc)
+{
+	return desc->limit0 | (desc->limit << 16);
+}
+
+static inline int desc_empty(const void *ptr)
+{
+	const uint32_t *desc = ptr;
+	return !(desc[0] | desc[1]);
+}
+
+static void fill_user_desc(struct user_desc *info, int idx,
+			   struct desc_struct *desc)
+
+{
+	memset(info, 0, sizeof(*info));
+	info->entry_number = idx;
+	info->base_addr = get_desc_base(desc);
+	info->limit = get_desc_limit(desc);
+	info->seg_32bit = desc->d;
+	info->contents = desc->type >> 2;
+	info->read_exec_only = !(desc->type & 2);
+	info->limit_in_pages = desc->g;
+	info->seg_not_present = !desc->p;
+	info->useable = desc->avl;
+#ifdef X86_64
+        info->lm = desc->l;
+#endif
+}
+
+static int regset_tls_active(struct task_context *target,
+			     const struct user_regset *regset)
+{
+	int i, nr_entries;
+	struct desc_struct *tls_array;
+
+	nr_entries = GCORE_SIZE(thread_struct_tls_array) / sizeof(uint64_t);
+
+	tls_array = (struct desc_struct *)GETBUF(GCORE_SIZE(thread_struct_tls_array));
+
+	readmem(target->task + OFFSET(task_struct_thread)
+		+ GCORE_OFFSET(thread_struct_tls_array), KVADDR,
+		tls_array, GCORE_SIZE(thread_struct_tls_array),
+		"regset_tls_active: t",
+		gcore_verbose_error_handle());
+
+	for (i = 0; i < nr_entries; ++i) {
+		if (!desc_empty(&tls_array[i])) {
+			FREEBUF(tls_array);
+			return TRUE;
+		}
+	}
+
+	FREEBUF(tls_array);
+	return FALSE;
+}
+
+static int regset_tls_get(struct task_context *target,
+			  const struct user_regset *regset,
+			  unsigned int size,
+			  void *buf)
+{
+	struct user_desc *info = (struct user_desc *)buf;
+	int i, nr_entries;
+	struct desc_struct *tls_array;
+
+	nr_entries = GCORE_SIZE(thread_struct_tls_array) / sizeof(uint64_t);
+
+	tls_array = (struct desc_struct *)GETBUF(GCORE_SIZE(thread_struct_tls_array));
+
+	readmem(target->task + OFFSET(task_struct_thread)
+		+ GCORE_OFFSET(thread_struct_tls_array), KVADDR,
+		tls_array, GCORE_SIZE(thread_struct_tls_array),
+		"regset_tls_active: tls_array",
+		gcore_verbose_error_handle());
+
+	for (i = 0; i < nr_entries; ++i) {
+		fill_user_desc(&info[i], GDT_ENTRY_TLS_MIN + i, &tls_array[i]);
+	}
+
+	FREEBUF(tls_array);
+	return 0;
+}
+
+#define IO_BITMAP_BITS  65536
+#define IO_BITMAP_BYTES (IO_BITMAP_BITS/8)
+#define IO_BITMAP_LONGS (IO_BITMAP_BYTES/sizeof(long))
+
+static int
+ioperm_active(struct task_context *target,
+	      const struct user_regset *regset)
+{
+	ulong io_bitmap_ptr;
+	unsigned int io_bitmap_max;
+	ulong io_bitmap;
+
+	if (MEMBER_EXISTS("thread_struct", "io_bitmap_max")) {
+		readmem(target->task + OFFSET(task_struct_thread) +
+			GCORE_OFFSET(thread_struct_io_bitmap_max), KVADDR,
+			&io_bitmap_max, sizeof(io_bitmap_max),
+			"ioperm_active: io_bitmap_max",
+			gcore_verbose_error_handle());
+		readmem(target->task + OFFSET(task_struct_thread) +
+			GCORE_OFFSET(thread_struct_io_bitmap_ptr), KVADDR,
+			&io_bitmap_ptr, sizeof(io_bitmap_ptr),
+			"ioperm_get: io_bitmap_ptr",
+			gcore_verbose_error_handle());
+		return io_bitmap_max && io_bitmap_ptr;
+	} else {
+		readmem(target->task + OFFSET(task_struct_thread) +
+			MEMBER_OFFSET("thread_struct", "io_bitmap"), KVADDR,
+			&io_bitmap, sizeof(io_bitmap),
+			"ioperm_active: io_bitmap",
+			gcore_verbose_error_handle());
+		if (!io_bitmap)
+			return 0;
+		readmem(io_bitmap + MEMBER_OFFSET("io_bitmap", "max"),
+			KVADDR,
+			&io_bitmap_max, sizeof(io_bitmap_max),
+			"ioperm_get: io_bitmap->max",
+			gcore_verbose_error_handle());
+		return divideup(io_bitmap_max, regset->size);
+	}
+}
+
+static int ioperm_get(struct task_context *target,
+		      const struct user_regset *regset,
+		      unsigned int size,
+		      void *buf)
+{
+	ulong io_bitmap_ptr;
+	ulong io_bitmap;
+
+	if (MEMBER_EXISTS("thread_struct", "io_bitmap_max")) {
+		readmem(target->task + OFFSET(task_struct_thread) +
+			GCORE_OFFSET(thread_struct_io_bitmap_ptr), KVADDR,
+			&io_bitmap_ptr, sizeof(io_bitmap_ptr),
+			"ioperm_get: io_bitmap_ptr", gcore_verbose_error_handle());
+	} else {
+		readmem(target->task + OFFSET(task_struct_thread) +
+			MEMBER_OFFSET("thread_struct", "io_bitmap"), KVADDR,
+			&io_bitmap, sizeof(io_bitmap),
+			"ioperm_active: io_bitmap",
+			gcore_verbose_error_handle());
+		if (!io_bitmap)
+			return -1;
+		io_bitmap_ptr = io_bitmap + MEMBER_OFFSET("io_bitmap", "bitmap");
+	}
+	readmem(io_bitmap_ptr, KVADDR, buf, size, "ioperm_get: copy IO bitmap",
+		gcore_verbose_error_handle());
+	return 0;
+}
+
+#ifdef X86_64
+#define __NR_rt_sigreturn	 15
+#define __NR_clone		 56
+#define __NR_fork		 57
+#define __NR_vfork		 58
+#define __NR_execve		 59
+#define __NR_iopl		172
+#define __NR_rt_sigsuspend      130
+#define __NR_sigaltstack	131
+
+static int is_special_syscall_v26(int nr_syscall)
+{
+	return nr_syscall == __NR_fork
+		|| nr_syscall == __NR_execve
+		|| nr_syscall == __NR_iopl
+		|| nr_syscall == __NR_clone
+		|| nr_syscall == __NR_rt_sigreturn
+		|| nr_syscall == __NR_sigaltstack
+		|| nr_syscall == __NR_vfork;
+}
+
+static int is_special_syscall_v0(int nr_syscall)
+{
+	return is_special_syscall_v26(nr_syscall)
+		|| nr_syscall == __NR_rt_sigsuspend;
+}
+
+#define IA32_SYSCALL_VECTOR 0x80
+
+#define __KERNEL_CS 0x10
+#endif
+
+//extern struct gate_struct idt_table[]; 
+enum { 
+	GATE_INTERRUPT = 0xE, 
+	GATE_TRAP = 0xF, 
+	GATE_CALL = 0xC,
+}; 
+
+#ifdef X86_64
+/* 16byte gate */
+struct gate_struct64 {
+        uint16_t offset_low;
+	uint16_t segment;
+	unsigned int ist : 3, zero0 : 5, type : 5, dpl : 2, p : 1;
+	uint16_t offset_middle;
+	uint32_t offset_high;
+	uint32_t zero1;
+} __attribute__((packed));
+#endif
+
+#define PTR_LOW(x) ((unsigned long)(x) & 0xFFFF) 
+#define PTR_MIDDLE(x) (((unsigned long)(x) >> 16) & 0xFFFF)
+#define PTR_HIGH(x) ((unsigned long)(x) >> 32)
+
+#ifdef X86_64
+/*
+ * compare gate structure data in crash kernel directly with the
+ * expected data in order to check wheather IA32_EMULATION feature was
+ * set or not.
+ *
+ * To check only wheather the space is filled with 0 or not is an
+ * alternate way to acheve the same purpose, but here I don't do so.
+ */
+static int is_gate_set_ia32_syscall_vector(void)
+{
+	struct gate_struct64 gate, gate_idt;
+	const ulong ia32_syscall_entry = symbol_value("ia32_syscall");
+
+	gate.offset_low = PTR_LOW(ia32_syscall_entry);
+	gate.segment = __KERNEL_CS;
+	gate.ist = 0;
+	gate.p = 1;
+	gate.dpl = 0x3;
+	gate.zero0 = 0;
+	gate.zero1 = 0;
+	gate.type = GATE_INTERRUPT;
+	gate.offset_middle = PTR_MIDDLE(ia32_syscall_entry);
+	gate.offset_high = PTR_HIGH(ia32_syscall_entry);
+
+	readmem(symbol_value("idt_table") + 16 * IA32_SYSCALL_VECTOR, KVADDR,
+		&gate_idt, sizeof(gate_idt), "is_gate_set_ia32_syscall_vector:"
+		" idt_table[IA32_SYSCALL_VECTOR", gcore_verbose_error_handle());
+
+	return !memcmp(&gate, &gate_idt, sizeof(struct gate_struct64));
+}
+
+#define IA32_SYSCALL_VECTOR          0x80
+
+#define __NR_ia32_fork               2
+#define __NR_ia32_execve             11
+#define __NR_ia32_sigsuspend         72
+#define __NR_ia32_iopl               110
+#define __NR_ia32_sigreturn          119
+#define __NR_ia32_clone              120
+#define __NR_ia32_sys32_rt_sigreturn 173
+#define __NR_ia32_rt_sigsuspend      179
+#define __NR_ia32_sigaltstack        186
+#define __NR_ia32_vfork              190
+
+/*
+ * is_special_ia32_syscall() field is initialized only when
+ * IA32_SYSCALL_VECTOR(0x80) is set to used_vectors. This check is
+ * made in gcore_x86_table_init().
+ */
+static inline int is_ia32_syscall_enabled(void)
+{
+	return !!gxt->is_special_ia32_syscall;
+}
+
+static int is_special_ia32_syscall_v0(int nr_syscall)
+{
+	return is_special_ia32_syscall_v26(nr_syscall)
+		|| nr_syscall == __NR_ia32_sigsuspend
+		|| nr_syscall == __NR_ia32_rt_sigsuspend;
+}
+
+static int is_special_ia32_syscall_v26(int nr_syscall)
+{
+	return nr_syscall == __NR_ia32_fork
+		|| nr_syscall == __NR_ia32_sigreturn
+		|| nr_syscall == __NR_ia32_execve
+		|| nr_syscall == __NR_ia32_iopl
+		|| nr_syscall == __NR_ia32_clone
+		|| nr_syscall == __NR_ia32_sys32_rt_sigreturn
+		|| nr_syscall == __NR_ia32_sigaltstack
+		|| nr_syscall == __NR_ia32_vfork;
+}
+#endif /* X86_64 */
+
+static int tsk_used_math_v0(ulong task)
+{
+	unsigned short used_math;
+
+	readmem(task + GCORE_OFFSET(task_struct_used_math), KVADDR,
+		&used_math, sizeof(used_math), "tsk_used_math_v0: used_math",
+		gcore_verbose_error_handle());
+
+	return !!used_math;
+}
+
+static int tsk_used_math_v11(ulong task)
+{
+	unsigned long flags;
+
+	readmem(task + OFFSET(task_struct_flags), KVADDR, &flags,
+		sizeof(flags), "tsk_used_math_v11: flags",
+		gcore_verbose_error_handle());
+
+	return !!(flags & PF_USED_MATH);
+}
+
+static int tsk_used_math_v4_14(ulong task)
+{
+	unsigned char initialized;
+
+	if (!cpu_has_fxsr())
+		return 0;
+
+	readmem(task +
+		OFFSET(task_struct_thread) +
+		GCORE_OFFSET(thread_struct_fpu) +
+		MEMBER_OFFSET("fpu", "initialized"),
+		KVADDR,
+		&initialized,
+		sizeof(initialized),
+		"tsk_used_math_v4_14: initialized",
+		gcore_verbose_error_handle());
+
+	return !!initialized;
+}
+
+static inline int
+user_mode(const struct user_regs_struct *regs)
+{
+	return !!(regs->cs & 0x3);
+}
+
+#ifdef X86_64
+static int
+test_tsk_thread_flag(ulong task, int bit)
+{
+	uint32_t flags;
+	ulong thread_info;
+
+	thread_info = task_to_thread_info(task);
+
+	readmem(thread_info + OFFSET(thread_info_flags), KVADDR, &flags,
+		sizeof(flags), "test_tsk_thread_flag: flags",
+		gcore_verbose_error_handle());
+
+	return !!((1UL << bit) & flags);
+}
+
+static void
+restore_segment_registers(ulong task, struct user_regs_struct *regs)
+{
+	readmem(task + OFFSET(task_struct_thread) +
+		GCORE_OFFSET(thread_struct_fs), KVADDR, &regs->fs_base,
+		GCORE_SIZE(thread_struct_fs),
+		"restore_segment_registers: fs", gcore_verbose_error_handle());
+
+	if (!regs->fs_base) {
+
+		readmem(task + OFFSET(task_struct_thread) +
+			GCORE_OFFSET(thread_struct_fsindex), KVADDR,
+			&regs->fs_base, GCORE_SIZE(thread_struct_fsindex),
+			"restore_segment_registers: fsindex",
+			gcore_verbose_error_handle());
+
+		if (regs->fs_base != FS_TLS_SEL)
+			regs->fs_base = 0;
+		else {
+			struct desc_struct desc;
+
+			readmem(task + OFFSET(task_struct_thread) +
+				FS_TLS * SIZE(desc_struct), KVADDR, &desc,
+				sizeof(desc),
+				"restore_segment_registers: desc",
+				gcore_verbose_error_handle());
+
+			regs->fs_base = get_desc_base(&desc);
+		}
+	}
+
+	readmem(task + OFFSET(task_struct_thread) +
+		GCORE_OFFSET(thread_struct_gsindex), KVADDR, &regs->gs_base,
+		GCORE_SIZE(thread_struct_gsindex),
+		"restore_segment_registers: gsindex", gcore_verbose_error_handle());
+
+	if (!regs->gs_base) {
+
+		readmem(task + OFFSET(task_struct_thread) +
+			GCORE_OFFSET(thread_struct_gs), KVADDR,	&regs->gs_base,
+			GCORE_SIZE(thread_struct_gs),
+			"restore_segment_registers: gs", gcore_verbose_error_handle());
+
+		if (regs->gs_base != GS_TLS_SEL)
+			regs->gs_base = 0;
+		else {
+			struct desc_struct desc;
+
+			readmem(task + OFFSET(task_struct_thread) +
+				GS_TLS * SIZE(desc_struct), KVADDR, &desc,
+				sizeof(desc),
+				"restore_segment_registers: desc",
+				gcore_verbose_error_handle());
+
+			regs->gs_base = get_desc_base(&desc);
+		}
+	}
+
+	if (test_tsk_thread_flag(task, TIF_FORCED_TF))
+		regs->flags &= ~X86_EFLAGS_TF;
+
+	readmem(task + OFFSET(task_struct_thread) +
+		GCORE_OFFSET(thread_struct_fsindex), KVADDR, &regs->fs,
+		GCORE_SIZE(thread_struct_fsindex),
+		"restore_segment_registers: fsindex",
+		gcore_verbose_error_handle());
+
+	readmem(task + OFFSET(task_struct_thread) +
+		GCORE_OFFSET(thread_struct_gsindex), KVADDR, &regs->gs,
+		GCORE_SIZE(thread_struct_gsindex),
+		"restore_segment_registers: gsindex",
+		gcore_verbose_error_handle());
+
+	readmem(task + OFFSET(task_struct_thread) +
+		GCORE_OFFSET(thread_struct_ds), KVADDR, &regs->ds,
+		GCORE_SIZE(thread_struct_ds),
+		"restore_segment_registers: ds",
+		gcore_verbose_error_handle());
+
+	readmem(task + OFFSET(task_struct_thread) +
+		GCORE_OFFSET(thread_struct_es), KVADDR, &regs->es,
+		GCORE_SIZE(thread_struct_es),
+		"restore_segment_registers: es",
+		gcore_verbose_error_handle());
+
+	regs->flags &= 0xffff;
+	regs->fs_base &= 0xffff;
+	regs->gs_base &= 0xffff;
+	regs->ds &= 0xffff;
+	regs->es &= 0xffff;
+	regs->fs &= 0xffff;
+	regs->gs &= 0xffff;
+
+}
+
+/**
+ * restore_frame_pointer - restore user-mode frame pointer
+ *
+ * @task interesting task
+ *
+ * If the kernel is built with CONFIG_FRAME_POINTER=y, we can find a
+ * user-mode frame pointer by tracing frame pointers from the one
+ * saved at scheduler. The reasons why this is possible include the
+ * fact that entry_64.S doesn't touch any callee-saved registers
+ * including frame pointer, rbp.
+ *
+ * On the other hand, if the kernel is not built with
+ * CONFIG_FRAME_POINTER=y, we need to depend on CFA information
+ * provided by kernel debugging information.
+ */
+static ulong restore_frame_pointer(ulong task)
+{
+	ulong rsp, rbp, prev_rbp, stacktop, stackbase;
+
+	/*
+	 * rsp is saved in task->thread.sp during switch_to().
+	 */
+	readmem(task + OFFSET(task_struct_thread) +
+		OFFSET(thread_struct_rsp), KVADDR, &rsp, sizeof(rsp),
+		"restore_frame_pointer: rsp", gcore_verbose_error_handle());
+
+	/*
+	 * rbp is saved at the point referred to by rsp
+	 */
+	readmem(rsp, KVADDR, &rbp, sizeof(rbp), "restore_frame_pointer: rbp",
+		gcore_verbose_error_handle());
+
+	/*
+	 * resume to the last rbp in user-mode.
+	 *
+	 * rbp in user-mode can have arbitrary value, so we need to
+	 * check whether rbp points onto the kernel stack or not.
+	 *
+	 * To make this operation always terminate, we check if rbp
+	 * value is strictly increasing (on x86_64, kernel stack grows
+	 * in the decreasing direction), which is sufficient for
+	 * termination property since the kernel stack size is finite.
+	 *
+	 * NOTE: This operation doesn't support tasks carrying in rbp
+	 * the values except for any user-mode address.
+	 *
+	 * The reason is that if rbp in user-mode is accidentally
+	 * equal to one of the remaining addresses in the kernel
+	 * stack, we cannot distinguish it from the rbp actually
+	 * pointing onto the kernel stack.
+	 *
+	 * It consequently takes, as rbp's, the value of another
+	 * register referred to by the address.
+	 */
+	stackbase = machdep->get_stackbase(task);
+	stacktop = machdep->get_stacktop(task);
+
+	prev_rbp = 0;
+
+	while (prev_rbp < rbp && rbp < stacktop && rbp >= stackbase) {
+		prev_rbp = rbp;
+		readmem(rbp, KVADDR, &rbp, sizeof(rbp),
+			"restore_frame_pointer: resume rbp",
+			gcore_verbose_error_handle());
+	}
+
+	return rbp;
+}
+
+/*
+ * We should avoid using pt_regs directly since it depends on kernel
+ * versions, and should also handle here using offsets prepared by
+ * crash utility. But unwind() is currently implemented using pt_regs
+ * and it's still under investigation on how to replace them by offset
+ * handling. So, we're in the meanwhile forced to use unwind() without
+ * any change.
+ */
+
+struct gcore_x86_64_pt_regs {
+        unsigned long r15;
+        unsigned long r14;
+        unsigned long r13;
+        unsigned long r12;
+        unsigned long rbp;
+        unsigned long rbx;
+/* arguments: non interrupts/non tracing syscalls only save upto here*/
+        unsigned long r11;
+        unsigned long r10;
+        unsigned long r9;
+        unsigned long r8;
+        unsigned long rax;
+        unsigned long rcx;
+        unsigned long rdx;
+        unsigned long rsi;
+        unsigned long rdi;
+        unsigned long orig_rax;
+/* end of arguments */
+/* cpu exception frame or undefined */
+        unsigned long rip;
+        unsigned long cs;
+        unsigned long eflags;
+        unsigned long rsp;
+        unsigned long ss;
+/* top of stack page */
+};
+
+struct unwind_frame_info
+{
+	struct gcore_x86_64_pt_regs regs;
+};
+
+extern int unwind(struct unwind_frame_info *frame, int is_ehframe);
+
+/**
+ * restore_rest() - restore user-mode callee-saved registers
+ *
+ * @task interesting task object
+ * @regs buffer into which register values are placed
+ * @active_regs active register values
+ *
+ * SAVE_ARGS() doesn't save callee-saved registers: rbx, r12, r13, r14
+ * and r15 because they are automatically saved at kernel stack frame
+ * that is made by the first C function call from entry_64.S.
+ *
+ * To retrieve these values correctly, it is necessary to use CFA,
+ * Cannonical Frame Address, which is specified as part of Dwarf, in
+ * order to calculate accurate offsets to where individual register is
+ * saved.
+ *
+ * @active_regs is a starting point of backtracing for active tasks.
+ *
+ * There are two kinds of sections for CFA to be placed in ELF's
+ * debugging inforamtion sections: .eh_frame and .debug_frame. The
+ * point is that two sections have differnet layout. Look carefully at
+ * is_ehframe.
+ */
+static inline void restore_rest(ulong task, struct user_regs_struct *regs,
+				const struct user_regs_struct *active_regs)
+{
+	struct unwind_frame_info frame;
+	int first_frame;
+	const int is_ehframe = (!st->dwarf_debug_frame_size && st->dwarf_eh_frame_size);
+
+	/*
+	 * For active processes, all values at crash are available, so
+	 * we pass them to unwinder as an initial frame value.
+	 *
+	 * For suspended processes when panic occurs, only ip, sp and
+	 * bp values will be passed to unwind(), this seems enough for
+	 * backtracing currently.
+	 */
+	if (is_task_active(task)) {
+		memcpy(&frame.regs, active_regs, sizeof(frame.regs));
+	} else {
+		unsigned long rsp, rbp;
+
+		memset(&frame, 0, sizeof(frame));
+
+		readmem(task + OFFSET(task_struct_thread) +
+			OFFSET(thread_struct_rsp), KVADDR, &rsp, sizeof(rsp),
+			"restore_rest: rsp",
+			gcore_verbose_error_handle());
+		readmem(rsp, KVADDR, &rbp, sizeof(rbp), "restore_rest: rbp",
+			gcore_verbose_error_handle());
+
+		frame.regs.rip = machdep->machspec->thread_return;
+		frame.regs.rsp = rsp;
+		frame.regs.rbp = rbp;
+	}
+
+	/*
+	 * Unwind to the first stack frame in kernel.
+	 *
+	 * Object files built with recent tools contain Dwarf CFI
+	 * version 3 or later, and dwarf unwinder in crash utility
+	 * supports version 1 only; doesn't version 3 and later. It's
+	 * under investigation.
+	 *
+	 */
+	first_frame = FALSE;
+
+	while (!unwind(&frame, is_ehframe))
+		first_frame = TRUE;
+
+	if (first_frame) {
+		regs->r12 = frame.regs.r12;
+		regs->r13 = frame.regs.r13;
+		regs->r14 = frame.regs.r14;
+		regs->r15 = frame.regs.r15;
+		regs->bp = frame.regs.rbp;
+		regs->bx = frame.regs.rbx;
+	}
+
+	/*
+	 * If kernel was configured with CONFIG_FRAME_POINTER, we
+	 * could trace the value of bp until its value became a
+	 * user-space address. See comments of restore_frame_pointer.
+	 */
+	else if ((machdep->flags & FRAMEPOINTER) && !is_task_active(task)) {
+		regs->bp = restore_frame_pointer(task);
+	}
+}
+
+/**
+ * gcore_x86_64_get_old_rsp_zero() - get rsp at per-cpu area
+ *
+ * @cpu target CPU's CPU id
+ *
+ * Given a CPU id, returns a RSP value saved at per-cpu area for the
+ * CPU whose id is the given CPU id.
+ *
+ * This is a method of get_old_rsp() returning always 0 for when no
+ * appropriate method is found.
+ */
+static ulong gcore_x86_64_get_old_rsp_zero(int cpu)
+{
+	error(WARNING, "failed to detect location of sp register, forcing 0.\n");
+	return 0UL;
+}
+
+/**
+ * gcore_x86_64_get_old_rsp() - get rsp at per-cpu area
+ *
+ * @cpu target CPU's CPU id
+ *
+ * Given a CPU id, returns a RSP value saved at per-cpu area for the
+ * CPU whose id is the given CPU id.
+ */
+static ulong gcore_x86_64_get_old_rsp(int cpu)
+{
+	ulong old_rsp;
+
+	readmem(symbol_value("old_rsp") + kt->__per_cpu_offset[cpu],
+		KVADDR,	&old_rsp, sizeof(old_rsp),
+		"gcore_x86_64_get_old_rsp: old_rsp",
+		gcore_verbose_error_handle());
+
+	return old_rsp;
+}
+
+/**
+ * gcore_x86_64_get_per_cpu__old_rsp() - get rsp at per-cpu area
+ *
+ * @cpu target CPU's CPU id
+ *
+ * Given a CPU id, returns a RSP value saved at per-cpu area for the
+ * CPU whose id is the given CPU id.
+ */
+static ulong gcore_x86_64_get_per_cpu__old_rsp(int cpu)
+{
+	ulong per_cpu__old_rsp;
+
+	readmem(symbol_value("per_cpu__old_rsp") + kt->__per_cpu_offset[cpu],
+		KVADDR,	&per_cpu__old_rsp, sizeof(per_cpu__old_rsp),
+		"gcore_x86_64_get_per_cpu__old_rsp: per_cpu__old_rsp",
+		gcore_verbose_error_handle());
+
+	return per_cpu__old_rsp;
+}
+
+/**
+ * gcore_x86_64_get_cpu_pda_oldrsp() - get rsp at per-cpu area
+ *
+ * @cpu target CPU's CPU id
+ *
+ * Given a CPU id, returns a RSP value saved at per-cpu area for the
+ * CPU whose id is the given CPU id.
+ */
+static ulong gcore_x86_64_get_cpu_pda_oldrsp(int cpu)
+{
+	ulong oldrsp;
+	char *cpu_pda_buf = GETBUF(SIZE(x8664_pda));
+
+	readmem(symbol_value("cpu_pda") + sizeof(ulong) * SIZE(x8664_pda),
+		KVADDR, cpu_pda_buf, SIZE(x8664_pda),
+		"gcore_x86_64_get_cpu_pda_oldrsp: cpu_pda_buf",
+		gcore_verbose_error_handle());
+
+	oldrsp = ULONG(cpu_pda_buf + GCORE_OFFSET(x8664_pda_oldrsp));
+
+	FREEBUF(cpu_pda_buf);
+	return oldrsp;
+}
+
+/**
+ * gcore_x86_64_get_cpu__pda_oldrsp() - get rsp at per-cpu area
+ *
+ * @cpu target CPU's CPU id
+ *
+ * Given a CPU id, returns a RSP value saved at per-cpu area for the
+ * CPU whose id is the given CPU id.
+ */
+static ulong gcore_x86_64_get_cpu__pda_oldrsp(int cpu)
+{
+	ulong oldrsp, x8664_pda, _cpu_pda;
+
+	_cpu_pda = symbol_value("_cpu_pda");
+
+	readmem(_cpu_pda + sizeof(ulong) * cpu, KVADDR, &x8664_pda,
+		sizeof(x8664_pda),
+		"gcore_x86_64_get__cpu_pda_oldrsp: _cpu_pda",
+		gcore_verbose_error_handle());
+
+	readmem(x8664_pda + GCORE_OFFSET(x8664_pda_oldrsp), KVADDR,
+		&oldrsp, sizeof(oldrsp),
+		"gcore_x86_64_get_cpu_pda_oldrsp: oldrsp",
+		gcore_verbose_error_handle());
+
+	return oldrsp;
+}
+
+static ulong gcore_x86_64_user_stack_pointer_userrsp(struct task_context *tc)
+{
+	ulong usersp;
+
+	/*
+	 * rsp is saved in per-CPU old_rsp, which is saved in
+	 * thread->usersp at each context switch.
+	 */
+	if (is_task_active(tc->task))
+		return gxt->get_old_rsp(tc->processor);
+
+	readmem(tc->task + OFFSET(task_struct_thread) +
+		GCORE_OFFSET(thread_struct_usersp), KVADDR, &usersp,
+		sizeof(usersp),
+		"gcore_x86_64_user_stack_pointer_userrsp: usersp",
+		gcore_verbose_error_handle());
+
+	return usersp;
+}
+
+static ulong gcore_x86_64_user_stack_pointer_pt_regs(struct task_context *tc)
+{
+	char *pt_regs_buf;
+	ulong sp0, sp;
+	struct machine_specific *ms = machdep->machspec;
+
+	pt_regs_buf = GETBUF(SIZE(pt_regs));
+
+	readmem(tc->task + OFFSET(task_struct_thread) +
+		GCORE_OFFSET(thread_struct_sp0), KVADDR, &sp0,
+		sizeof(sp0),
+		"gcore_x86_64_user_stack_pointer_pt_regs: sp0",
+		gcore_verbose_error_handle());
+
+	readmem(sp0 - SIZE(pt_regs), KVADDR, pt_regs_buf, SIZE(pt_regs),
+		"gcore_x86_64_user_stack_pointer_pt_regs: pt_regs",
+		gcore_verbose_error_handle());
+
+	sp = ULONG(pt_regs_buf + ms->pto.rsp);
+
+	FREEBUF(pt_regs_buf);
+	return sp;
+}
+
+static int
+gcore_find_regs_from_bt_output(FILE *output, char *buf, size_t bufsize)
+{
+	while (fgets(buf, bufsize, output))
+		if (strncmp(buf, "    RIP:", 8) == 0)
+			return TRUE;
+
+	return FALSE;
+}
+
+static int
+gcore_get_regs_from_bt_output(FILE *output, struct user_regs_struct *regs)
+{
+	char buf[BUFSIZE];
+	int items __attribute__ ((__unused__));
+
+	if (gcore_find_regs_from_bt_output(output, buf, BUFSIZE) == FALSE)
+		return FALSE;
+
+	items = sscanf(buf, "    RIP: %016lx  RSP: %016lx  RFLAGS: %08lx\n",
+	       &regs->ip, &regs->sp, &regs->flags);
+	items = fscanf(output, "    RAX: %016lx  RBX: %016lx  RCX: %016lx\n",
+	       &regs->ax, &regs->bx, &regs->cx);
+	items = fscanf(output, "    RDX: %016lx  RSI: %016lx  RDI: %016lx\n",
+	       &regs->dx, &regs->si, &regs->di);
+	items = fscanf(output, "    RBP: %016lx   R8: %016lx   R9: %016lx\n",
+	       &regs->bp, &regs->r8, &regs->r9);
+	items = fscanf(output, "    R10: %016lx  R11: %016lx  R12: %016lx\n",
+	       &regs->r10, &regs->r11, &regs->r12);
+	items = fscanf(output, "    R13: %016lx  R14: %016lx  R15: %016lx\n",
+	       &regs->r13, &regs->r14, &regs->r15);
+	items = fscanf(output, "    ORIG_RAX: %016lx  CS: %04lx  SS: %04lx\n",
+	       &regs->orig_ax, &regs->cs, &regs->ss);
+
+	return TRUE;
+}
+
+static int
+gcore_get_regs_from_eframe(struct task_context *tc,
+			   struct user_regs_struct *regs)
+{
+	int ret;
+	struct bt_info bt;
+
+	BZERO(&bt, sizeof(struct bt_info));
+	bt.stackbuf = NULL;
+	bt.tc = tc;
+	bt.task = tc->task;
+	bt.stackbase = GET_STACKBASE(tc->task);
+	bt.stacktop = GET_STACKTOP(tc->task);
+
+	open_tmpfile();
+	back_trace(&bt);
+	rewind(pc->tmpfile);
+	ret = gcore_get_regs_from_bt_output(pc->tmpfile, regs);
+	close_tmpfile();
+
+	return ret;
+}
+
+static void
+get_regs_from_kvmdump_notes(struct task_context *target,
+			    struct user_regs_struct *regs)
+{
+	struct kvm_register_set krs;
+
+	BZERO(&krs, sizeof(krs));
+
+	if (!get_kvm_register_set(target->processor, &krs))
+		return;
+
+	regs->cs = krs.x86.cs;
+	regs->ss = krs.x86.ss;
+	regs->ds = krs.x86.ds;
+	regs->es = krs.x86.es;
+	regs->fs = krs.x86.fs;
+	regs->gs = krs.x86.gs;
+	regs->ip = krs.x86.ip;
+	regs->flags = krs.x86.flags;
+	regs->ax = krs.x86.regs[0];
+	regs->cx = krs.x86.regs[1];
+	regs->dx = krs.x86.regs[2];
+	regs->bx = krs.x86.regs[3];
+	regs->sp = krs.x86.regs[4];
+	regs->bp = krs.x86.regs[5];
+	regs->si = krs.x86.regs[6];
+	regs->di = krs.x86.regs[7];
+	regs->r8 = krs.x86.regs[8];
+	regs->r9 = krs.x86.regs[9];
+	regs->r10 = krs.x86.regs[10];
+	regs->r11 = krs.x86.regs[11];
+	regs->r12 = krs.x86.regs[12];
+	regs->r13 = krs.x86.regs[13];
+	regs->r14 = krs.x86.regs[14];
+	regs->r15 = krs.x86.regs[15];
+}
+
+static int get_active_regs(struct task_context *target,
+			   struct user_regs_struct *regs)
+{
+	if (KVMDUMP_DUMPFILE()) {
+		get_regs_from_kvmdump_notes(target, regs);
+		return TRUE;
+	}
+
+	if ((NETDUMP_DUMPFILE() || KDUMP_DUMPFILE()) &&
+	    exist_regs_in_elf_notes((void *)target)) {
+		struct user_regs_struct *note =	get_regs_from_elf_notes(target);
+		memcpy(regs, note, sizeof(struct user_regs_struct));
+		return TRUE;
+	}
+
+	if (gcore_get_regs_from_eframe(target, regs)) {
+		/*
+		 * EFRAME contains CS and SS only. Here collects the
+		 * remaining part of segment registers.
+		 */
+		restore_segment_registers(target->task, regs);
+		return TRUE;
+	}
+
+	return FALSE;
+}
+
+enum gcore_kernel_entry
+{
+	GCORE_KERNEL_ENTRY_UNKNOWN = 0,
+	GCORE_KERNEL_ENTRY_INVALID_VECTOR,
+	GCORE_KERNEL_ENTRY_NMI_EXCEPTION,
+	GCORE_KERNEL_ENTRY_INTEL_RESERVED,
+	GCORE_KERNEL_ENTRY_IRQ,
+	GCORE_KERNEL_ENTRY_SYSCALL,
+	GCORE_KERNEL_ENTRY_SYSENTER32,
+	GCORE_KERNEL_ENTRY_SYSCALL32,
+	GCORE_KERNEL_ENTRY_INT80,
+	GCORE_KERNEL_ENTRY_IA32_UNKNOWN
+};
+
+enum {
+	GCORE_SYSCALL_OPCODE_BYTES = 2
+};
+
+static const unsigned char GCORE_OPCODE_SYSCALL[] = {0x0f, 0x05};
+static const unsigned char GCORE_OPCODE_SYSENTER[] = {0x0f, 0x34};
+static const unsigned char GCORE_OPCODE_INT80[] = {0xcd, 0x80};
+
+/**
+ * check how @target entered kernel-mode.
+ * @target target task context object
+ * @regs pt_regs structure at the bottom of @target's kernel stack
+ */
+static enum gcore_kernel_entry
+check_kernel_entry(struct task_context *target, struct user_regs_struct *regs)
+{
+	/*
+	 * regs->orig_ax contains either a signal number or an IRQ
+	 * number: if >=0, it's a signal number; if <0, it's an IRQ
+	 * number.
+	 */
+	if ((int)regs->orig_ax >= 0) {
+		physaddr_t paddr;
+		unsigned char opcode[GCORE_SYSCALL_OPCODE_BYTES];
+
+		if (!gcore_is_arch_32bit_emulation(target))
+			return GCORE_KERNEL_ENTRY_SYSCALL;
+
+		if (!uvtop(target, regs->ip - sizeof(opcode), &paddr, FALSE))
+			return GCORE_KERNEL_ENTRY_IA32_UNKNOWN;
+			
+		readmem(paddr, PHYSADDR, opcode, sizeof(opcode),
+			"check_context: opcode", gcore_verbose_error_handle());
+
+		if (memcmp(opcode, GCORE_OPCODE_SYSCALL, sizeof(opcode)) == 0)
+			return GCORE_KERNEL_ENTRY_SYSCALL32;
+
+		if (memcmp(opcode, GCORE_OPCODE_INT80, sizeof(opcode)) == 0)
+			return GCORE_KERNEL_ENTRY_INT80;
+
+		if (!uvtop(target,
+			   regs->ip
+			   - 2 /* jmp enter_kernel or int 0x80 */
+			   - 7 /* nop alignment bytes */
+			   - sizeof(opcode), /* sysenter */
+			   &paddr, FALSE))
+			return GCORE_KERNEL_ENTRY_IA32_UNKNOWN;
+
+		readmem(paddr, PHYSADDR, opcode, sizeof(opcode),
+			"check_context: opcode 2", gcore_verbose_error_handle());
+
+		if (memcmp(opcode, GCORE_OPCODE_SYSENTER, sizeof(opcode)) == 0)
+			return GCORE_KERNEL_ENTRY_SYSENTER32;
+
+		return GCORE_KERNEL_ENTRY_IA32_UNKNOWN;
+
+	} else {
+		const int vector = (int)~regs->orig_ax;
+
+		if (vector < 0 || vector > 255)
+			return GCORE_KERNEL_ENTRY_INVALID_VECTOR;
+
+		if (vector < 20)
+			return GCORE_KERNEL_ENTRY_NMI_EXCEPTION;
+
+		if (vector < 32)
+			return GCORE_KERNEL_ENTRY_INTEL_RESERVED;
+
+		if (vector < 256)
+			return GCORE_KERNEL_ENTRY_IRQ;
+
+	}
+
+	return GCORE_KERNEL_ENTRY_UNKNOWN;
+}
+
+/**
+ * Restore registers saved in system_call entry.
+ * @target target task context object
+ * @regs pt_regs structure at the bottom of @target's kernel stack
+ * @active_regs active registers; used if @target is active
+ */
+static void
+restore_regs_syscall_context(struct task_context *target,
+			     struct user_regs_struct *regs,
+			     struct user_regs_struct *active_regs)
+{
+	const int nr_syscall = (int)regs->orig_ax;
+
+	if (gxt->user_stack_pointer)
+		regs->sp = gxt->user_stack_pointer(target);
+
+	/*
+	 * entire registers are saved for special system calls.
+	 */
+	if (!gxt->is_special_syscall(nr_syscall))
+		restore_rest(target->task, regs, active_regs);
+
+	/*
+	 * See FIXUP_TOP_OF_STACK in arch/x86/kernel/entry_64.S.
+	 */
+	regs->ss = __USER_DS;
+	regs->cs = __USER_CS;
+	regs->cx = (ulong)-1;
+	regs->flags = regs->r11;
+
+	restore_segment_registers(target->task, regs);
+}
+
+static void
+restore_regs_ia32_syscall_common(struct task_context *target,
+				 struct user_regs_struct *regs,
+				 struct user_regs_struct *active_regs)
+{
+	const int nr_syscall = (int)regs->orig_ax;
+
+	if (!gxt->is_special_ia32_syscall(nr_syscall))
+		restore_rest(target->task, regs, active_regs);
+
+	restore_segment_registers(target->task, regs);
+}
+
+static void
+restore_regs_sysenter32_context(struct task_context *target,
+				struct user_regs_struct *regs,
+				struct user_regs_struct *active_regs)
+{
+	restore_regs_ia32_syscall_common(target, regs, active_regs);
+
+	/*
+	 * clear IF (bit 9): Interrupt enable flag
+	 */
+	regs->flags &= ~0x200;
+}
+
+static void
+restore_regs_syscall32_context(struct task_context *target,
+			       struct user_regs_struct *regs,
+			       struct user_regs_struct *active_regs)
+{
+	restore_regs_ia32_syscall_common(target, regs, active_regs);
+}
+
+static int genregs_get(struct task_context *target,
+		       const struct user_regset *regset,
+		       unsigned int size, void *buf)
+{
+	char *pt_regs_buf;
+	struct user_regs_struct *regs = (struct user_regs_struct *)buf;
+	struct user_regs_struct active_regs;
+	const int active = is_task_active(target->task);
+	struct machine_specific *ms = machdep->machspec;
+
+	BZERO(regs, sizeof(*regs));
+
+	if (active && get_active_regs(target, &active_regs)) {
+		if (user_mode(&active_regs)) {
+			memcpy(regs, &active_regs, sizeof(*regs));
+			return 0;
+		}
+	}
+
+	/*
+	 * SAVE_ARGS() and SAVE_ALL() macros save user-mode register
+	 * values at kernel stack top when entering kernel-mode at
+	 * interrupt.
+	 */
+	pt_regs_buf = GETBUF(SIZE(pt_regs));
+
+	readmem(machdep->get_stacktop(target->task) - SIZE(pt_regs), KVADDR,
+		pt_regs_buf, SIZE(pt_regs), "genregs_get: pt_regs",
+		gcore_verbose_error_handle());
+
+	regs->ip = ULONG(pt_regs_buf + ms->pto.rip);
+	regs->sp = ULONG(pt_regs_buf + ms->pto.rsp);
+	regs->cs = ULONG(pt_regs_buf + ms->pto.cs);
+	regs->ss = ULONG(pt_regs_buf + ms->pto.ss);
+	regs->flags = ULONG(pt_regs_buf + ms->pto.eflags);
+	regs->orig_ax = ULONG(pt_regs_buf + ms->pto.orig_rax);
+	regs->bp = ULONG(pt_regs_buf + ms->pto.rbp);
+	regs->ax = ULONG(pt_regs_buf + ms->pto.rax);
+	regs->bx = ULONG(pt_regs_buf + ms->pto.rbx);
+	regs->cx = ULONG(pt_regs_buf + ms->pto.rcx);
+	regs->dx = ULONG(pt_regs_buf + ms->pto.rdx);
+	regs->si = ULONG(pt_regs_buf + ms->pto.rsi);
+	regs->di = ULONG(pt_regs_buf + ms->pto.rdi);
+	regs->r8 = ULONG(pt_regs_buf + ms->pto.r8);
+	regs->r9 = ULONG(pt_regs_buf + ms->pto.r9);
+	regs->r10 = ULONG(pt_regs_buf + ms->pto.r10);
+	regs->r11 = ULONG(pt_regs_buf + ms->pto.r11);
+	regs->r12 = ULONG(pt_regs_buf + ms->pto.r12);
+	regs->r13 = ULONG(pt_regs_buf + ms->pto.r13);
+	regs->r14 = ULONG(pt_regs_buf + ms->pto.r14);
+	regs->r15 = ULONG(pt_regs_buf + ms->pto.r15);
+
+	FREEBUF(pt_regs_buf);
+
+	switch (check_kernel_entry(target, regs)) {
+	case GCORE_KERNEL_ENTRY_UNKNOWN:
+		error(WARNING, "unknown kernel entry.\n");
+		break;
+	case GCORE_KERNEL_ENTRY_INVALID_VECTOR: {
+		const int vector = (int)regs->orig_ax;
+		error(WARNING, "unexpected IRQ number: %d.\n", vector);
+		break;
+	}
+	case GCORE_KERNEL_ENTRY_INTEL_RESERVED: {
+		const int vector = (int)regs->orig_ax;
+		error(WARNING, "IRQ number %d is reserved by Intel\n", vector);
+	}
+		break;
+	case GCORE_KERNEL_ENTRY_NMI_EXCEPTION:
+		restore_segment_registers(target->task, regs);
+		break;
+	case GCORE_KERNEL_ENTRY_IA32_UNKNOWN:
+		error(WARNING,
+		      "system call instruction used could not be found\n");
+	case GCORE_KERNEL_ENTRY_IRQ:
+	case GCORE_KERNEL_ENTRY_INT80:
+		/*
+		 * The commit ff467594f2a4be01a0fa5e9ffc223fa930d232dd
+		 * in the linux kernel begins saving all registers
+		 * including callee-saved registers on the bottom of
+		 * the kernel stack even on the IRQ entry. I'm very
+		 * happy.
+		 */
+		if (THIS_KERNEL_VERSION < LINUX(4,2,0))
+			restore_rest(target->task, regs, &active_regs);
+		restore_rest(target->task, regs, &active_regs);
+		restore_segment_registers(target->task, regs);
+		break;
+	case GCORE_KERNEL_ENTRY_SYSCALL:
+		restore_regs_syscall_context(target, regs, &active_regs);
+		break;
+	case GCORE_KERNEL_ENTRY_SYSENTER32:
+		restore_regs_sysenter32_context(target, regs, &active_regs);
+		break;
+	case GCORE_KERNEL_ENTRY_SYSCALL32:
+		restore_regs_syscall32_context(target, regs, &active_regs);
+		break;
+	}
+
+	return 0;
+}
+#endif /* X86_64 */
+
+#ifndef ARRAY_SIZE
+#  define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+#endif
+
+static inline int test_bit(unsigned int nr, const ulong addr)
+{
+	ulong nth_entry;
+
+	readmem(addr + (nr / 64) * sizeof(ulong), KVADDR, &nth_entry,
+		sizeof(nth_entry), "test_bit: nth_entry", gcore_verbose_error_handle());
+
+	return !!((1UL << (nr % 64)) & nth_entry);
+}
+
+#ifdef X86_64
+static void gcore_x86_table_register_get_old_rsp(void)
+{
+	if (symbol_exists("old_rsp"))
+		gxt->get_old_rsp = gcore_x86_64_get_old_rsp;
+
+	else if (symbol_exists("per_cpu__old_rsp"))
+		gxt->get_old_rsp = gcore_x86_64_get_per_cpu__old_rsp;
+
+	else if (symbol_exists("cpu_pda"))
+		gxt->get_old_rsp = gcore_x86_64_get_cpu_pda_oldrsp;
+
+	else if (symbol_exists("_cpu_pda"))
+		gxt->get_old_rsp = gcore_x86_64_get_cpu__pda_oldrsp;
+
+	else
+		gxt->get_old_rsp = gcore_x86_64_get_old_rsp_zero;
+}
+
+static void gcore_x86_table_register_user_stack_pointer(void)
+{
+	if (MEMBER_EXISTS("thread_struct", "usersp") ||
+	    MEMBER_EXISTS("thread_struct", "userrsp"))
+		gxt->user_stack_pointer = gcore_x86_64_user_stack_pointer_userrsp;
+
+	else if (MEMBER_EXISTS("thread_struct", "sp0"))
+		gxt->user_stack_pointer = gcore_x86_64_user_stack_pointer_pt_regs;
+}
+#endif
+
+static void gcore_x86_table_register_get_thread_struct_fpu(void)
+{
+	if (MEMBER_EXISTS("thread_struct", "fpu")) {
+		if (MEMBER_OFFSET("fpu", "state") == 8)
+			gxt->get_thread_struct_fpu =
+				gcore_x86_get_thread_struct_fpu_thread_xstate;
+		else
+			gxt->get_thread_struct_fpu =
+				gcore_x86_get_thread_struct_fpu_fpregs_state;
+		gxt->get_thread_struct_fpu_size =
+			gcore_x86_get_thread_struct_fpu_thread_xstate_size;
+	} else if (MEMBER_EXISTS("thread_struct", "xstate")) {
+		gxt->get_thread_struct_fpu =
+			gcore_x86_get_thread_struct_thread_xstate;
+		gxt->get_thread_struct_fpu_size =
+			gcore_x86_get_thread_struct_thread_xstate_size;
+	} else if (MEMBER_EXISTS("thread_struct", "i387")) {
+		gxt->get_thread_struct_fpu =
+			gcore_x86_get_thread_struct_i387;
+		gxt->get_thread_struct_fpu_size =
+			gcore_x86_get_thread_struct_i387_size;
+	}
+}
+
+#ifdef X86_64
+/*
+ * Some special system calls got not special at v2.6.26.
+ *
+ * commit 5f0120b5786f5dbe097a946a2eb5d745ebc2b7ed
+ */
+static void gcore_x86_table_register_is_special_syscall(void)
+{
+	if (symbol_exists("stub_rt_sigsuspend"))
+		gxt->is_special_syscall = is_special_syscall_v0;
+	else
+		gxt->is_special_syscall = is_special_syscall_v26;
+}
+
+/*
+ * Some special system calls got not special at v2.6.26.
+ *
+ * commit 5f0120b5786f5dbe097a946a2eb5d745ebc2b7ed
+ */
+static void gcore_x86_table_register_is_special_ia32_syscall(void)
+{
+	if (symbol_exists("ia32_syscall") &&
+	    ((symbol_exists("used_vectors") &&
+	      test_bit(IA32_SYSCALL_VECTOR, symbol_value("used_vectors"))) ||
+	     is_gate_set_ia32_syscall_vector())) {
+		if (symbol_exists("stub32_rt_sigsuspend"))
+			gxt->is_special_ia32_syscall =
+				is_special_ia32_syscall_v0;
+		else
+			gxt->is_special_ia32_syscall =
+				is_special_ia32_syscall_v26;
+	}
+}
+#endif
+
+/*
+ * used_math member of task_struct structure was removed. Instead,
+ * PF_USED_MATH was introduced and has been used now.
+ *
+ * Between 2.6.10 and 2.6.11.
+ */
+static void gcore_x86_table_register_tsk_used_math(void)
+{
+	if (MEMBER_EXISTS("fpu", "initialized"))
+		gxt->tsk_used_math = tsk_used_math_v4_14;
+	else if (GCORE_VALID_MEMBER(task_struct_used_math))
+		gxt->tsk_used_math = tsk_used_math_v0;
+	else
+		gxt->tsk_used_math = tsk_used_math_v11;
+
+}
+
+#ifdef X86_64
+void gcore_x86_table_init(void)
+{
+	gcore_x86_table_register_get_old_rsp();
+	gcore_x86_table_register_user_stack_pointer();
+	gcore_x86_table_register_get_thread_struct_fpu();
+	gcore_x86_table_register_is_special_syscall();
+	gcore_x86_table_register_is_special_ia32_syscall();
+	gcore_x86_table_register_tsk_used_math();
+}
+
+static struct user_regset x86_64_regsets[] = {
+	[REGSET_GENERAL] = {
+		.core_note_type = NT_PRSTATUS,
+		.size = sizeof(struct user_regs_struct),
+		.get = genregs_get
+	},
+	[REGSET_FP] = {
+		.core_note_type = NT_FPREGSET,
+		.name = "CORE",
+		.size = sizeof(struct user_i387_struct),
+		.active = xfpregs_active,
+		.get = xfpregs_get,
+	},
+	[REGSET_XSTATE] = {
+		.name = "CORE",
+		.size = sizeof(uint64_t),
+		.active = xstateregs_active,
+		.get = xstateregs_get,
+	},
+	[REGSET_IOPERM64] = {
+		.core_note_type = NT_386_IOPERM,
+		.name = "CORE",
+		.size = IO_BITMAP_LONGS * sizeof(long),
+		.active = ioperm_active,
+		.get = ioperm_get
+	},
+};
+
+static const struct user_regset_view x86_64_regset_view = {
+	.name = "x86_64",
+	.regsets = x86_64_regsets,
+	.n = ARRAY_SIZE(x86_64_regsets),
+	.e_machine = EM_X86_64,
+};
+
+/*
+ * The number of registers for REGSET_XSTATE entry is specified
+ * dynamically. So, we need to look at it directly.
+ */
+static void gcore_x86_64_regset_xstate_init(void)
+{
+	struct user_regset *regset_xstate = &x86_64_regsets[REGSET_XSTATE];
+
+	regset_xstate->size = sizeof(uint64_t) * get_xstate_regsets_number();
+}
+
+void gcore_x86_64_regsets_init(void)
+{
+	gcore_x86_64_regset_xstate_init();
+
+	x86_64_exception_frame(EFRAME_INIT, 0, NULL, NULL, NULL);
+}
+
+static int genregs_get32(struct task_context *target,
+			 const struct user_regset *regset,
+			 unsigned int size, void *buf)
+{
+	struct user_regs_struct32 *r32 = buf;
+	struct user_regset *x86_64_gen = &x86_64_regsets[REGSET_GENERAL];
+	struct user_regs_struct r64;
+
+	if (x86_64_gen->get(target, x86_64_gen, sizeof(r64), &r64))
+		return 1;
+
+	BZERO(r32, sizeof(*r32));
+
+	r32->ebx = r64.bx;
+	r32->ecx = r64.cx;
+	r32->edx = r64.dx;
+	r32->esi = r64.si;
+	r32->edi = r64.di;
+	r32->ebp = r64.bp;
+	r32->eax = r64.ax;
+	r32->ds = r64.ds;
+	r32->es = r64.es;
+	r32->fs = r64.fs;
+	r32->gs = r64.gs;
+	r32->orig_eax = r64.orig_ax;
+	r32->eip = r64.ip;
+	r32->cs = r64.cs;
+	r32->eflags = r64.flags;
+	r32->esp = r64.sp;
+	r32->ss = r64.ss;
+
+	return 0;
+}
+
+#endif /* X86_64 */
+
+#ifdef X86
+static void
+get_regs_from_kvmdump_notes(struct task_context *target,
+			    struct user_regs_struct *regs)
+{
+	struct kvm_register_set krs;
+
+	BZERO(&krs, sizeof(krs));
+
+	if (!get_kvm_register_set(target->processor, &krs))
+		return;
+
+	regs->ax = krs.x86.regs[0];
+	regs->cx = krs.x86.regs[1];
+	regs->dx = krs.x86.regs[2];
+	regs->bx = krs.x86.regs[3];
+	regs->sp = krs.x86.regs[4];
+	regs->bp = krs.x86.regs[5];
+	regs->si = krs.x86.regs[6];
+	regs->di = krs.x86.regs[7];
+	regs->cs = krs.x86.cs;
+	regs->ss = krs.x86.ss;
+	regs->ds = krs.x86.ds;
+	regs->es = krs.x86.es;
+	regs->fs = krs.x86.fs;
+	regs->gs = krs.x86.gs;
+	regs->ip = krs.x86.ip;
+	regs->flags = krs.x86.flags;
+}
+
+static int genregs_get32(struct task_context *target,
+			 const struct user_regset *regset,
+			 unsigned int size, void *buf)
+{
+	struct user_regs_struct *regs = (struct user_regs_struct *)buf;
+	char *pt_regs_buf;
+	ulonglong pt_regs_addr;
+
+	if (is_task_active(target->task) && KVMDUMP_DUMPFILE()) {
+		get_regs_from_kvmdump_notes(target, regs);
+		if (user_mode(regs)) {
+			return TRUE;
+		}
+	}
+
+	pt_regs_buf = GETBUF(SIZE(pt_regs));
+
+	pt_regs_addr = machdep->get_stacktop(target->task) - SIZE(pt_regs);
+
+	/*
+	 * The commit 07b047fc2466249aff7cdb23fa0b0955a7a00d48
+	 * introduced 8-byte offset to match copy_thread().
+	 */
+	if (THIS_KERNEL_VERSION >= LINUX(2,6,16))
+		pt_regs_addr -= 8;
+
+	readmem(pt_regs_addr, KVADDR, pt_regs_buf, SIZE(pt_regs),
+		"genregs_get32: regs", gcore_verbose_error_handle());
+
+	BZERO(regs, sizeof(struct user_regs_struct));
+
+        regs->ax = ULONG(pt_regs_buf + GCORE_OFFSET(pt_regs_ax));
+        regs->bp = ULONG(pt_regs_buf + GCORE_OFFSET(pt_regs_bp));
+        regs->bx = ULONG(pt_regs_buf + GCORE_OFFSET(pt_regs_bx));
+        regs->cs = ULONG(pt_regs_buf + GCORE_OFFSET(pt_regs_cs));
+        regs->cx = ULONG(pt_regs_buf + GCORE_OFFSET(pt_regs_cx));
+        regs->di = ULONG(pt_regs_buf + GCORE_OFFSET(pt_regs_di));
+        regs->ds = ULONG(pt_regs_buf + GCORE_OFFSET(pt_regs_ds));
+        regs->dx = ULONG(pt_regs_buf + GCORE_OFFSET(pt_regs_dx));
+        regs->es = ULONG(pt_regs_buf + GCORE_OFFSET(pt_regs_es));
+        regs->flags = ULONG(pt_regs_buf + GCORE_OFFSET(pt_regs_flags));
+        regs->ip = ULONG(pt_regs_buf + GCORE_OFFSET(pt_regs_ip));
+        regs->orig_ax = ULONG(pt_regs_buf + GCORE_OFFSET(pt_regs_orig_ax));
+        regs->si = ULONG(pt_regs_buf + GCORE_OFFSET(pt_regs_si));
+        regs->sp = ULONG(pt_regs_buf + GCORE_OFFSET(pt_regs_sp));
+        regs->ss = ULONG(pt_regs_buf + GCORE_OFFSET(pt_regs_ss));
+
+	if (GCORE_VALID_MEMBER(pt_regs_fs))
+		regs->fs = ULONG(pt_regs_buf + GCORE_OFFSET(pt_regs_fs));
+	else if (GCORE_VALID_MEMBER(pt_regs_xfs))
+		regs->fs = ULONG(pt_regs_buf + GCORE_OFFSET(pt_regs_xfs));
+	if (GCORE_VALID_MEMBER(pt_regs_gs))
+		regs->gs = ULONG(pt_regs_buf + GCORE_OFFSET(pt_regs_gs));
+	else if (GCORE_VALID_MEMBER(pt_regs_xgs))
+		regs->gs = ULONG(pt_regs_buf + GCORE_OFFSET(pt_regs_xgs));
+
+	regs->ds &= 0xffff;
+	regs->es &= 0xffff;
+	regs->fs &= 0xffff;
+	regs->gs &= 0xffff;
+	regs->ss &= 0xffff;
+
+	FREEBUF(pt_regs_buf);
+
+	/*
+	 * If LAZY_GS is set, 0 is pushed on gs position at kernel
+	 * stack's bottom. Then, gs value we want is at thread->gs,
+	 * saved during __switch_to().
+	 */
+	if (GCORE_VALID_MEMBER(pt_regs_gs) && regs->gs == 0) {
+		readmem(target->task + OFFSET(task_struct_thread) +
+			GCORE_OFFSET(thread_struct_gs), KVADDR, &regs->gs,
+			sizeof(regs->gs), "genregs_get32: regs->gs",
+			gcore_verbose_error_handle());
+
+		regs->gs &= 0xffff;
+
+                /*
+		 * If gs is handled lazily, it's impossible to restore
+		 * gs value for active tasks that had never been
+		 * scheduled even once since entering kernel-execution
+		 * mode.
+		 */
+		if (is_task_active(target->task))
+			error(WARNING, "maybe cannot restore lazily-handled "
+			      "GS for active tasks.\n");
+	}
+
+	return TRUE;
+}
+
+void gcore_x86_table_init(void)
+{
+	gcore_x86_table_register_get_thread_struct_fpu();
+	gcore_x86_table_register_tsk_used_math();
+}
+
+#define user_regs_struct32 user_regs_struct
+
+#endif /* X86 */
+
+static struct user_regset x86_32_regsets[] = {
+	[REGSET_GENERAL] = {
+		.core_note_type = NT_PRSTATUS,
+		.name = "CORE",
+		.get = genregs_get32,
+		.size = sizeof(struct user_regs_struct32),
+	},
+	[REGSET_FP] = {
+		.core_note_type = NT_FPREGSET,
+		.name = "CORE",
+		.size = sizeof(struct user_i387_ia32_struct),
+		.active = fpregs_active, .get = fpregs_get,
+	},
+	[REGSET_XSTATE] = {
+		.name = "CORE",
+		.active = xstateregs_active, .get = xstateregs_get,
+	},
+	[REGSET_XFP] = {
+		.core_note_type = NT_PRXFPREG,
+		.name = "LINUX",
+		.size = sizeof(struct user32_fxsr_struct),
+		.active = xfpregs_active, .get = xfpregs_get,
+	},
+	[REGSET_TLS] = {
+		.core_note_type = NT_386_TLS,
+		.name = "CORE",
+		.size = GDT_ENTRY_TLS_ENTRIES * sizeof(struct user_desc),
+		.active = regset_tls_active,
+		.get = regset_tls_get,
+	},
+	[REGSET_IOPERM32] = {
+		.core_note_type = NT_386_IOPERM,
+		.name = "CORE",
+		.size = IO_BITMAP_BYTES,
+		.active = ioperm_active, .get = ioperm_get
+	},
+};
+
+static const struct user_regset_view x86_32_regset_view = {
+	.name = "x86_32",
+	.regsets = x86_32_regsets,
+	.n = ARRAY_SIZE(x86_32_regsets),
+	.e_machine = EM_386,
+};
+
+/*
+ * The number of registers for REGSET_XSTATE entry is specified
+ * dynamically. So, we need to look at it directly.
+ */
+static void gcore_x86_32_regset_xstate_init(void)
+{
+	struct user_regset *regset_xstate = &x86_32_regsets[REGSET_XSTATE];
+
+	regset_xstate->size = sizeof(uint32_t) * get_xstate_regsets_number();
+}
+
+void gcore_x86_32_regsets_init(void)
+{
+	gcore_x86_32_regset_xstate_init();
+}
+
+const struct user_regset_view *
+task_user_regset_view(void)
+{
+#ifdef X86_64
+	if (gcore_is_arch_32bit_emulation(CURRENT_CONTEXT()))
+#endif
+		return &x86_32_regset_view;
+#ifdef X86_64
+	return &x86_64_regset_view;
+#endif
+}
+
+/**
+ * If a given task @tc is running in IA32e compatibility mode on
+ * X86_64, return TRUE. Otherwise, return FALSE. On X86_32, always
+ * return FALSE.
+ *
+ * Assume all tasks in IA32e comp mode sets TIF_IA32 in thread_info
+ * flags.
+ */
+
+enum gcore_x86_thread_info_flag
+{
+	TIF_IA32 = 17 /* 32bit process */
+};
+
+int gcore_is_arch_32bit_emulation(struct task_context *tc)
+{
+#ifdef X86_64
+	uint32_t flags;
+	char *thread_info_buf;
+
+	thread_info_buf = fill_thread_info(tc->thread_info);
+	flags = ULONG(thread_info_buf + OFFSET(thread_info_flags));
+
+	if (flags & (1UL << TIF_IA32))
+		return TRUE;
+#endif
+	return FALSE;
+}
+
+/**
+ * Return an address to gate_vma.
+ */
+ulong gcore_arch_get_gate_vma(void)
+{
+#ifdef X86_64
+	if (gcore_is_arch_32bit_emulation(CURRENT_CONTEXT()))
+		return 0UL;
+
+	if (symbol_exists("vsyscall_mode")) {
+		enum { ENUMERATE, NONE } vsyscall_mode;
+
+		readmem(symbol_value("vsyscall_mode"),
+			KVADDR,
+			&vsyscall_mode,
+			sizeof(vsyscall_mode),
+			"gcore_arch_get_gate_vma: vsyscall_mode",
+			gcore_verbose_error_handle());
+
+		if (vsyscall_mode == NONE)
+			return 0UL;
+	}
+
+	return symbol_value("gate_vma");
+#else
+	return 0UL;
+#endif
+}
+
+char *gcore_arch_vma_name(ulong vma)
+{
+	ulong mm, vm_start, vdso;
+
+	readmem(vma + OFFSET(vm_area_struct_vm_mm), KVADDR, &mm, sizeof(mm),
+		"gcore_arch_vma_name: vma->vm_mm",
+		gcore_verbose_error_handle());
+
+	readmem(vma + OFFSET(vm_area_struct_vm_start), KVADDR, &vm_start,
+		sizeof(vm_start), "gcore_arch_vma_name: vma->vm_start",
+		gcore_verbose_error_handle());
+
+	/*
+	 * The commit "x86_64: Add vDSO for x86-64 with
+	 * gettimeofday/clock_gettime/getcpu"
+	 * (2aae950b21e4bc789d1fc6668faf67e8748300b7) adds vDSO
+	 * support. Since then, the starting address of vDSO mapping
+	 * is decided at the start of process execution and assigned
+	 * at mm_context_t::vdso.
+	 */
+	if (GCORE_OFFSET(mm_context_t_vdso) >= 0) {
+		readmem(mm + GCORE_OFFSET(mm_struct_context) +
+			GCORE_OFFSET(mm_context_t_vdso), KVADDR, &vdso,
+			sizeof(vdso), "gcore_arch_vma_name: mm->context.vdso",
+			gcore_verbose_error_handle());
+	} else {
+		vdso = VDSO_HIGH_BASE;
+	}
+
+	if (mm && vm_start == vdso)
+		return "[vdso]";
+	if (vma == symbol_value("gate_vma"))
+		return "[vsyscall]";
+	return NULL;
+}
+
+/**
+ * VM_ALWAYSDUMP flag was removed when introducing VM_DONTDUMP
+ * flag. We need to determine which flag is present on a given
+ * dumpfile. A simple idea is to look up existence of symbol
+ * always_dump_vma, which was again newly introduced at the same time
+ * of removal of VM_ALWAYSDUMP flag. Unfortunately, gcc removes the
+ * function by function inlining optimization, we cannot use
+ * it. Instead, as a workaround, we look up vsyscall page and try to
+ * determine if the VM_ALWAYSDUMP flag is being set on the vma
+ * corresponding to vsyscall page.
+ */
+int gcore_arch_vsyscall_has_vm_alwaysdump_flag(void)
+{
+	char *vma_cache;
+	ulong target_vma, gate_vma, vm_flags;
+
+	target_vma = 0UL;
+
+	if ((gate_vma = gcore_arch_get_gate_vma()))
+		target_vma = gate_vma;
+	else {
+		ulong vma, index, mmap = 0UL;
+
+		FOR_EACH_VMA_OBJECT(vma, index, mmap, gate_vma) {
+			if (gcore_arch_vma_name(vma)) {
+				target_vma = vma;
+				break;
+			}
+		}
+	}
+
+	if (!target_vma)
+		return FALSE;
+
+	vma_cache = fill_vma_cache(target_vma);
+	vm_flags = ULONG(vma_cache + OFFSET(vm_area_struct_vm_flags));
+
+	return (vm_flags & VM_ALWAYSDUMP) ? TRUE : FALSE;
+}
+
+int gcore_arch_get_fp_valid(struct task_context *tc)
+{
+	const struct user_regset *regset =
+#ifdef X86_64
+		gcore_is_arch_32bit_emulation(tc)
+		? &x86_32_regsets[REGSET_FP]
+		: &x86_64_regsets[REGSET_FP]
+#else
+		&x86_32_regsets[REGSET_FP]
+#endif
+		;
+	char *buf = GETBUF(regset->size);
+	int retval = FALSE;
+
+	if (regset->active(tc, regset) &&
+	    !regset->get(tc, regset, regset->size, buf))
+		retval = TRUE;
+
+	FREEBUF(buf);
+	return retval;
+}
+
+#endif /* defined(X86) || defined(X86_64) */


### PR DESCRIPTION
Make gcore work to get core dump of user space processes from a kernel dump.

This issue is being discussed [here.](https://github.com/crash-utility/crash-extensions/issues/2)